### PR TITLE
fix clang 3.3 warning in linux kore_platform_init

### DIFF
--- a/src/linux.c
+++ b/src/linux.c
@@ -52,9 +52,13 @@ static struct epoll_event	*events = NULL;
 void
 kore_platform_init(void)
 {
-	if ((cpu_count = sysconf(_SC_NPROCESSORS_ONLN)) == -1) {
+	long	n;
+
+	if ((n = sysconf(_SC_NPROCESSORS_ONLN)) == -1) {
 		kore_debug("could not get number of cpu's falling back to 1");
 		cpu_count = 1;
+	} else {
+		cpu_count = (u_int16_t)n;
 	}
 }
 


### PR DESCRIPTION
```
src/linux.c:55:50: warning: comparison of constant -1 with expression of type
      'u_int16_t' (aka 'unsigned short') is always false
      [-Wtautological-constant-out-of-range-compare]
        if ((cpu_count = sysconf(_SC_NPROCESSORS_ONLN)) == -1) {
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~
```
