### PR TITLE
Gardening include directives.

### DIFF
--- a/includes/http.h
+++ b/includes/http.h
@@ -17,6 +17,9 @@
 #ifndef __H_HTTP_H
 #define __H_HTTP_H
 
+#include <sys/types.h>
+#include <sys/queue.h>
+
 #define HTTP_HEADER_MAX_LEN	8192
 #define HTTP_URI_LEN		2000
 #define HTTP_USERAGENT_LEN	256

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -17,6 +17,19 @@
 #ifndef __H_KORE_H
 #define __H_KORE_H
 
+#include "spdy.h"
+
+#include <regex.h>
+#include <zlib.h>
+
+#include <openssl/ssl.h>
+
+#include <arpa/inet.h>
+
+#include <sys/types.h>
+#include <sys/queue.h>
+
+
 #define KORE_RESULT_ERROR	0
 #define KORE_RESULT_OK		1
 #define KORE_RESULT_RETRY	2

--- a/includes/spdy.h
+++ b/includes/spdy.h
@@ -17,6 +17,9 @@
 #ifndef __H_SPDY_H
 #define __H_SPDY_H
 
+#include <sys/types.h>
+#include <sys/queue.h>
+
 struct spdy_ctrl_frame {
 	u_int16_t	version;
 	u_int16_t	type;

--- a/modules/example/src/example.c
+++ b/modules/example/src/example.c
@@ -14,27 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <errno.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <regex.h>
-#include <unistd.h>
-#include <zlib.h>
-
-#include "spdy.h"
 #include "kore.h"
 #include "http.h"
 

--- a/modules/example/tools/inject.c
+++ b/modules/example/tools/inject.c
@@ -14,10 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
 #include <sys/stat.h>
 
-#include <ctype.h>
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/src/accesslog.c
+++ b/src/accesslog.c
@@ -14,31 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <errno.h>
-#include <fcntl.h>
-#include <poll.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <syslog.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
 #include "kore.h"
 #include "http.h"
+
+#include <errno.h>
+#include <poll.h>
+#include <syslog.h>
 
 static int		accesslog_fd[2];
 

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -14,6 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include "spdy.h"
+#include "kore.h"
+#include "http.h"
+
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -38,10 +42,6 @@
 #include <regex.h>
 #include <zlib.h>
 #include <unistd.h>
-
-#include "spdy.h"
-#include "kore.h"
-#include "http.h"
 
 static int			kfd = -1;
 static struct kevent		*events;

--- a/src/buf.c
+++ b/src/buf.c
@@ -14,27 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <errno.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
 #include "kore.h"
 
 struct kore_buf *

--- a/src/config.c
+++ b/src/config.c
@@ -14,30 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
+#include "kore.h"
 
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pwd.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
-#include "kore.h"
 
 static int		configure_bind(char **);
 static int		configure_load(char **);

--- a/src/connection.c
+++ b/src/connection.c
@@ -14,36 +14,12 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-#include <sys/wait.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <pwd.h>
-#include <errno.h>
-#include <grp.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sched.h>
-#include <syslog.h>
-#include <time.h>
-#include <regex.h>
-#include <zlib.h>
-#include <unistd.h>
-
-#include "spdy.h"
 #include "kore.h"
 #include "http.h"
+
+#include <openssl/err.h>
+
+#include <fcntl.h>
 
 int
 kore_connection_accept(struct listener *l, struct connection **out)

--- a/src/domain.c
+++ b/src/domain.c
@@ -14,32 +14,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/stat.h>
-#include <sys/queue.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
+#include "kore.h"
 
 #include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <ctype.h>
-#include <dlfcn.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <syslog.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
-#include "kore.h"
 
 struct kore_domain_h		domains;
 struct kore_domain		*primary_dom = NULL;

--- a/src/http.c
+++ b/src/http.c
@@ -14,30 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <errno.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <regex.h>
-#include <time.h>
-#include <zlib.h>
-
-#include "spdy.h"
 #include "kore.h"
 #include "http.h"
+
+#include <sys/param.h>
 
 static int		http_post_data_recv(struct netbuf *);
 static int		http_send_done(struct netbuf *);

--- a/src/kore.c
+++ b/src/kore.c
@@ -14,35 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-#include <sys/wait.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <pwd.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sched.h>
-#include <syslog.h>
-#include <time.h>
-#include <regex.h>
-#include <zlib.h>
-#include <unistd.h>
-
-#include "spdy.h"
 #include "kore.h"
-#include "http.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <syslog.h>
 
 volatile sig_atomic_t			sig_recv;
 

--- a/src/linux.c
+++ b/src/linux.c
@@ -14,36 +14,13 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
+#include "kore.h"
+
 #include <sys/epoll.h>
 #include <sys/prctl.h>
-#include <sys/wait.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
 
 #include <errno.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sched.h>
-#include <syslog.h>
-#include <time.h>
-#include <regex.h>
-#include <zlib.h>
-#include <unistd.h>
-
-#include "spdy.h"
-#include "kore.h"
-#include "http.h"
 
 static int			efd = -1;
 static u_int32_t		event_count = 0;

--- a/src/mem.c
+++ b/src/mem.c
@@ -14,30 +14,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-#include <sys/time.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
+#include "kore.h"
 
 #include <errno.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <syslog.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
-#include "kore.h"
 
 #define KORE_MEM_MAGIC		0xd0d0
 #define KORE_MEMINFO(x)		\

--- a/src/module.c
+++ b/src/module.c
@@ -14,32 +14,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
+#include "kore.h"
+
 #include <sys/stat.h>
-#include <sys/queue.h>
 
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <ctype.h>
 #include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <syslog.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
-#include "kore.h"
 
 static void		*mod_handle = NULL;
 static char		*mod_name = NULL;

--- a/src/net.c
+++ b/src/net.c
@@ -14,28 +14,9 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
+#include "kore.h"
 
 #include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <errno.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
-#include "kore.h"
 
 void
 net_send_queue(struct connection *c, u_int8_t *data, size_t len, int flags,

--- a/src/spdy.c
+++ b/src/spdy.c
@@ -14,27 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <errno.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
 #include "kore.h"
 #include "http.h"
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -14,30 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
-#include <sys/time.h>
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
+#include "kore.h"
 
 #include <errno.h>
-#include <fcntl.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <syslog.h>
-#include <regex.h>
-#include <zlib.h>
-
-#include "spdy.h"
-#include "kore.h"
 
 static struct {
 	char		*name;

--- a/src/worker.c
+++ b/src/worker.c
@@ -14,38 +14,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/queue.h>
+#include "kore.h"
+#include "http.h"
+
 #include <sys/ipc.h>
 #include <sys/shm.h>
 #include <sys/wait.h>
 
-#include <netinet/in.h>
-#include <arpa/inet.h>
-
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
 #include <pwd.h>
 #include <errno.h>
 #include <grp.h>
-#include <fcntl.h>
-#include <regex.h>
 #include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <syslog.h>
-#include <semaphore.h>
-#include <time.h>
-#include <unistd.h>
-#include <zlib.h>
-
-#include "spdy.h"
-#include "kore.h"
-#include "http.h"
 
 //#define WORKER_DEBUG		1
 


### PR DESCRIPTION
Each .c file now only includes what it needs and headers can be included without
needing a magic incantation of includes preceding it. Previously one needed to
included all the files which are now in kore.h before kore.h.

When people include their own headers last, projects can get into this state
because it becomes unclear what any particular header needs.

I know I touched a lot of files, but I thought this gardening might be helpful. Unfortunately I do not have a BSD box so I didn't dare touch bsd.c.
