### PR TITLE
Make Kore compilation compatible with OSX

### DIFF
--- a/src/bsd.c
+++ b/src/bsd.c
@@ -147,5 +147,7 @@ kore_platform_disable_accept(void)
 void
 kore_platform_proctitle(char *title)
 {
+#ifndef __MACH__
 	setproctitle("%s", title);
+#endif
 }

--- a/src/domain.c
+++ b/src/domain.c
@@ -72,7 +72,9 @@ kore_domain_sslstart(struct kore_domain *dom)
 	if (!SSL_CTX_check_private_key(dom->ssl_ctx))
 		fatal("Public/Private key for %s do not match", dom->domain);
 
+#ifdef SSL_MODE_RELEASE_BUFFERS
 	SSL_CTX_set_mode(dom->ssl_ctx, SSL_MODE_RELEASE_BUFFERS);
+#endif
 	SSL_CTX_set_cipher_list(dom->ssl_ctx, kore_ssl_cipher_list);
 	SSL_CTX_set_mode(dom->ssl_ctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
 	SSL_CTX_set_options(dom->ssl_ctx, SSL_OP_NO_SSLv2);

--- a/src/worker.c
+++ b/src/worker.c
@@ -179,8 +179,15 @@ kore_worker_entry(struct kore_worker *kw)
 		fatal("cannot chroot(): %s", errno_s);
 	if (chdir("/") == -1)
 		fatal("cannot chdir(): %s", errno_s);
-	if (setgroups(1, &pw->pw_gid) || setresgid(pw->pw_gid, pw->pw_gid,
-	    pw->pw_gid) || setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid))
+	if (setgroups(1, &pw->pw_gid) ||
+#ifdef __MACH__
+    setgid(pw->pw_gid) || setegid(pw->pw_gid) ||
+    setuid(pw->pw_uid) || seteuid(pw->pw_uid)
+#else
+    setresgid(pw->pw_gid, pw->pw_gid, pw->pw_gid) ||
+    setresuid(pw->pw_uid, pw->pw_uid, pw->pw_uid)
+#endif
+   )
 		fatal("unable to drop privileges");
 
 	snprintf(buf, sizeof(buf), "kore [wrk %d]", kw->id);


### PR DESCRIPTION
Kore was not compiling on OSX throwing the following errors:

```
src/domain.c:75: error: ‘SSL_MODE_RELEASE_BUFFERS’ undeclared (first use in this function)
src/domain.c:75: error: (Each undeclared identifier is reported only once
src/domain.c:75: error: for each function it appears in.)
...
Undefined symbols for architecture x86_64:
  "_setresgid", referenced from:
      _kore_worker_entry in worker.o
  "_setresuid", referenced from:
      _kore_worker_entry in worker.o
  "_setproctitle", referenced from:
      _kore_platform_proctitle in bsd.o
```

This fix resolves those errors ensuring Kore compiles fine and works as desired on OSX.

Tested with:
Macbook Air Mid-2012 with OSX Mountain Lion 10.8.2
