### PR TITLE
Apply correct number of workers based on cores for OSX

### DIFF
--- a/src/bsd.c
+++ b/src/bsd.c
@@ -17,6 +17,10 @@
 #include <sys/param.h>
 #include <sys/event.h>
 
+#ifdef __MACH__
+    #include <sys/sysctl.h>
+#endif
+
 #include "kore.h"
 
 static int			kfd = -1;
@@ -28,7 +32,24 @@ static u_int32_t		event_count = 0;
 void
 kore_platform_init(void)
 {
-	cpu_count = 0;
+    cpu_count = 0;
+
+#ifdef __MACH__
+    long n;
+    int mib[] = { CTL_HW, HW_AVAILCPU };
+    size_t len = sizeof(n);
+
+    sysctl(mib, 2, &n, &len, NULL, 0);
+    if (n < 1) {
+        mib[1] = HW_NCPU;
+        sysctl(mib, 2, &n, &len, NULL, 0);
+    }
+
+    if (n >= 1) {
+        cpu_count = (u_int16_t)n;
+    }
+#endif /* __MACH__ */
+
 }
 
 void


### PR DESCRIPTION
Fix for the following issue on a multi-core system.

```
[66412] src/worker.c:89 - kore_worker_init(): system has 0 cpu's
[66412] src/worker.c:90 - kore_worker_init(): starting 4 workers
[66412] src/worker.c:92 - kore_worker_init(): more workers then cpu's
```

It should detect the system to have proper number of cpus (cores) and then spawn workers based on that.

``` bash
$ sysctl -n machdep.cpu.brand_string
Intel(R) Core(TM) i7-3667U CPU @ 2.00GHz
$ sysctl hw.availcpu
hw.availcpu = 4
$ sysctl hw.ncpu
hw.ncpu: 4
```
