### PR TITLE
HTTP status code texts

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -22,48 +22,53 @@
 #include "kore.h"
 #include "http.h"
 
-const char *http_code_phrase[] = {
-	[100] = "Continue",
-	[101] = "Switching Protocols",
-	[200] = "OK",
-	[201] = "Created",
-	[202] = "Accepted",
-	[203] = "Non-Authoritative Information",
-	[204] = "No Content",
-	[205] = "Reset Content",
-	[206] = "Partial Content",
-	[300] = "Multiple Choices",
-	[301] = "Moved Permanently",
-	[302] = "Found",
-	[303] = "See Other",
-	[304] = "Not Modified",
-	[305] = "Use Proxy",
-	[307] = "Temporary Redirect",
-	[400] = "Bad Request",
-	[401] = "Unauthorized",
-	[402] = "Payment Required",
-	[403] = "Forbidden",
-	[404] = "Not Found",
-	[405] = "Method Not Allowed",
-	[406] = "Not Acceptable",
-	[407] = "Proxy Authentication Required",
-	[408] = "Request Time-out",
-	[409] = "Conflict",
-	[410] = "Gone",
-	[411] = "Length Required",
-	[412] = "Precondition Failed",
-	[413] = "Request Entity Too Large",
-	[414] = "Request-URI Too Large",
-	[415] = "Unsupported Media Type",
-	[416] = "Requested range not satisfiable",
-	[417] = "Expectation Failed",
-	[500] = "Internal Server Error",
-	[501] = "Not Implemented",
-	[502] = "Bad Gateway",
-	[503] = "Service Unavailable",
-	[504] = "Gateway Time-out",
-	[505] = "HTTP Version not supported"
-};
+char*
+http_get_code_phrase(int code) {
+	char *r = "Unknown code";
+	switch (code) {
+		case 100: r = "Continue"; break;
+		case 101: r = "Switching Protocols"; break;
+		case 200: r = "OK"; break;
+		case 201: r = "Created"; break;
+		case 202: r = "Accepted"; break;
+		case 203: r = "Non-Authoritative Information"; break;
+		case 204: r = "No Content"; break;
+		case 205: r = "Reset Content"; break;
+		case 206: r = "Partial Content"; break;
+		case 300: r = "Multiple Choices"; break;
+		case 301: r = "Moved Permanently"; break;
+		case 302: r = "Found"; break;
+		case 303: r = "See Other"; break;
+		case 304: r = "Not Modified"; break;
+		case 305: r = "Use Proxy"; break;
+		case 307: r = "Temporary Redirect"; break;
+		case 400: r = "Bad Request"; break;
+		case 401: r = "Unauthorized"; break;
+		case 402: r = "Payment Required"; break;
+		case 403: r = "Forbidden"; break;
+		case 404: r = "Not Found"; break;
+		case 405: r = "Method Not Allowed"; break;
+		case 406: r = "Not Acceptable"; break;
+		case 407: r = "Proxy Authentication Required"; break;
+		case 408: r = "Request Time-out"; break;
+		case 409: r = "Conflict"; break;
+		case 410: r = "Gone"; break;
+		case 411: r = "Length Required"; break;
+		case 412: r = "Precondition Failed"; break;
+		case 413: r = "Request Entity Too Large"; break;
+		case 414: r = "Request-URI Too Large"; break;
+		case 415: r = "Unsupported Media Type"; break;
+		case 416: r = "Requested range not satisfiable"; break;
+		case 417: r = "Expectation Failed"; break;
+		case 500: r = "Internal Server Error"; break;
+		case 501: r = "Not Implemented"; break;
+		case 502: r = "Bad Gateway"; break;
+		case 503: r = "Service Unavailable"; break;
+		case 504: r = "Gateway Time-out"; break;
+		case 505: r = "HTTP Version not supported"; break;
+	}
+	return r;
+}
 
 static int		http_post_data_recv(struct netbuf *);
 static int		http_send_done(struct netbuf *);
@@ -269,7 +274,7 @@ http_response(struct http_request *req, int status, u_int8_t *d, u_int32_t len)
 
 	req->status = status;
 	if (req->owner->proto == CONN_PROTO_SPDY) {
-		snprintf(sbuf, sizeof(sbuf), "%d %s", status, http_code_phrase[status]);
+		snprintf(sbuf, sizeof(sbuf), "%d %s", status, http_get_code_phrase(status));
 
 		hblock = spdy_header_block_create(SPDY_HBLOCK_NORMAL);
 		spdy_header_block_add(hblock, ":status", sbuf);


### PR DESCRIPTION
Hello,
Due to HTTP RFC — http://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1 — status text phrases are required in HTTP headers. Most of parsers allows to omit them, but some ones (e.g. Erlang's httpc module) fail. Here I've wrote a small patch to fix this problem. Could you please merge it to upstream?

Regards.
