### PR TITLE
Add required header for proper OpenBSD checking

### DIFF
--- a/src/domain.c
+++ b/src/domain.c
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <sys/param.h>
+
 #include "kore.h"
 
 #define SSL_SESSION_ID		"kore_ssl_sessionid"


### PR DESCRIPTION
Sorry I'm always late with my OpenBSD fixes, but this fixes the defined(OpenBSD) checks in domain.c for ssl_ctx->freelist_max_len.
