### PR TITLE
Honor CC from the environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Kore Makefile
 
-CC=gcc
+CC?=gcc
 KORE=kore
 INSTALL_DIR=/usr/local/bin
 INCLUDE_DIR=/usr/local/include/kore


### PR DESCRIPTION
Allows for spiffyness

``` bash
CC=clang make
clang -Wall -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -Iincludes -g -D_GNU_SOURCE=1 -c src/config.c -o src/config.o
...
```
