### PR TITLE
Added ability to set path prefix during make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # Kore Makefile
 
 CC?=gcc
+PREFIX?=/usr/local
 KORE=kore
-INSTALL_DIR=/usr/local/bin
-INCLUDE_DIR=/usr/local/include/kore
+INSTALL_DIR=$(PREFIX)/bin
+INCLUDE_DIR=$(PREFIX)/include/kore
 
 S_SRC=	src/kore.c src/accesslog.c src/auth.c src/buf.c src/cli.c src/config.c \
 	src/connection.c src/domain.c src/http.c src/mem.c src/module.c \
@@ -14,6 +15,7 @@ S_OBJS=	$(S_SRC:.c=.o)
 CFLAGS+=-Wall -Wstrict-prototypes -Wmissing-prototypes
 CFLAGS+=-Wmissing-declarations -Wshadow -Wpointer-arith -Wcast-qual
 CFLAGS+=-Wsign-compare -Iincludes -g
+CFLAGS+=-DPREFIX='"$(PREFIX)"'
 LDFLAGS+=-rdynamic -lssl -lcrypto -lz
 
 ifneq ("$(DEBUG)", "")
@@ -60,6 +62,7 @@ all: $(S_OBJS)
 
 install:
 	mkdir -p $(INCLUDE_DIR)
+	mkdir -p $(INSTALL_DIR)
 	install -m 555 $(KORE) $(INSTALL_DIR)/$(KORE)
 	install -m 644 includes/*.h $(INCLUDE_DIR)
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -844,7 +844,11 @@ cli_compile_cfile(void *arg)
 	args[idx++] = compiler;
 	args[idx++] = ipath[0];
 	args[idx++] = ipath[1];
+#if defined(PREFIX)
+	(void)cli_vasprintf(&args[idx++], "-I%s/include", PREFIX);
+#else
 	args[idx++] = "-I/usr/local/include";
+#endif
 
 #if defined(KORE_USE_PGSQL)
 	(void)cli_vasprintf(&ppath, "-I%s", PGSQL_INCLUDE_PATH);


### PR DESCRIPTION
In order to create a [Homebrew](https://github.com/Homebrew/homebrew) formula for Kore (https://github.com/Homebrew/homebrew/pull/34898), I created an ability to set the path `PREFIX` while compiling and installing with make. This enables a user to install Kore to any location.

What do think?
