### PR TITLE
Always write out content-length;

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -1264,7 +1264,7 @@ http_response_normal(struct http_request *req, struct connection *c,
 		}
 	}
 
-	if (len > 0)
+	if (status != 204 && 99 < status && status < 200)
 		kore_buf_appendf(header_buf, "content-length: %d\r\n", len);
 
 	kore_buf_append(header_buf, "\r\n", 2);


### PR DESCRIPTION
Unless status is 204 or 1xx (informational).

There are other cases where you are not permitted to write out the content-length, but they are
unsupported anyhow, see https://tools.ietf.org/html/rfc7230#section-3.3.2