### PR TITLE
Rename BENCHMARK to NO_SSL.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ ifneq ("$(KORE_PEDANTIC_MALLOC)", "")
 	CFLAGS+=-DKORE_PEDANTIC_MALLOC
 endif
 
-ifneq ("$(BENCHMARK)", "")
-	CFLAGS+=-DKORE_BENCHMARK
+ifneq ("$(NO_SSL)", "")
+	CFLAGS+=-DKORE_NO_SSL
 	LDFLAGS=-rdynamic -lz -lcrypto
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ ifneq ("$(KORE_PEDANTIC_MALLOC)", "")
 	CFLAGS+=-DKORE_PEDANTIC_MALLOC
 endif
 
-ifneq ("$(NO_SSL)", "")
-	CFLAGS+=-DKORE_NO_SSL
+ifneq ("$(NOTLS)", "")
+	CFLAGS+=-DKORE_NO_TLS
 	LDFLAGS=-rdynamic -lz -lcrypto
 endif
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ those by setting a shell environment variable before running **_make_**.
 * TASKS=1 (compiles in task support)
 * PGSQL=1 (compiles in pgsql support)
 * DEBUG=1 (enables use of -d for debug)
-* NO_SSL=1 (compiles Kore without OpenSSL)
+* NOTLS=1 (compiles Kore without OpenSSL)
 * KORE_PEDANTIC_MALLOC=1 (zero all allocated memory)
 
 Example libraries

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ those by setting a shell environment variable before running **_make_**.
 * TASKS=1 (compiles in task support)
 * PGSQL=1 (compiles in pgsql support)
 * DEBUG=1 (enables use of -d for debug)
-* BENCHMARK=1 (compiles Kore without OpenSSL)
+* NO_SSL=1 (compiles Kore without OpenSSL)
 * KORE_PEDANTIC_MALLOC=1 (zero all allocated memory)
 
 Example libraries

--- a/src/accesslog.c
+++ b/src/accesslog.c
@@ -184,7 +184,7 @@ kore_accesslog(struct http_request *req)
 	}
 
 	memset(logpacket.cn, '\0', sizeof(logpacket.cn));
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	if (req->owner->cert != NULL) {
 		if (X509_GET_CN(req->owner->cert,
 		    logpacket.cn, sizeof(logpacket.cn)) == -1) {

--- a/src/accesslog.c
+++ b/src/accesslog.c
@@ -184,7 +184,7 @@ kore_accesslog(struct http_request *req)
 	}
 
 	memset(logpacket.cn, '\0', sizeof(logpacket.cn));
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	if (req->owner->cert != NULL) {
 		if (X509_GET_CN(req->owner->cert,
 		    logpacket.cn, sizeof(logpacket.cn)) == -1) {

--- a/src/cli.c
+++ b/src/cli.c
@@ -135,7 +135,7 @@ static struct filegen gen_files[] = {
 
 static const char *gen_dirs[] = {
 	"src",
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	"cert",
 #endif
 	"conf",
@@ -161,19 +161,19 @@ static const char *config_data =
 	"\n"
 	"bind\t\t127.0.0.1 8888\n"
 	"load\t\t./%s.so\n"
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	"tls_dhparam\tdh2048.pem\n"
 #endif
 	"\n"
 	"domain 127.0.0.1 {\n"
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	"\tcertfile\tcert/server.crt\n"
 	"\tcertkey\t\tcert/server.key\n"
 #endif
 	"\tstatic\t/\tpage\n"
 	"}\n";
 
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 static const char *dh2048_data =
 	"-----BEGIN DH PARAMETERS-----\n"
 	"MIIBCAKCAQEAn4f4Qn5SudFjEYPWTbUaOTLUH85YWmmPFW1+b5bRa9ygr+1wfamv\n"
@@ -277,7 +277,7 @@ cli_create(int argc, char **argv)
 
 	printf("%s created succesfully!\n", appl);
 
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	printf("note: do NOT use the created DH parameters/certificates in production\n");
 #endif
 }
@@ -766,7 +766,7 @@ cli_find_files(const char *path, void (*cb)(char *, struct dirent *))
 static void
 cli_generate_certs(void)
 {
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	BIGNUM			*e;
 	FILE			*fp;
 	time_t			now;

--- a/src/cli.c
+++ b/src/cli.c
@@ -135,7 +135,7 @@ static struct filegen gen_files[] = {
 
 static const char *gen_dirs[] = {
 	"src",
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	"cert",
 #endif
 	"conf",
@@ -161,19 +161,19 @@ static const char *config_data =
 	"\n"
 	"bind\t\t127.0.0.1 8888\n"
 	"load\t\t./%s.so\n"
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	"tls_dhparam\tdh2048.pem\n"
 #endif
 	"\n"
 	"domain 127.0.0.1 {\n"
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	"\tcertfile\tcert/server.crt\n"
 	"\tcertkey\t\tcert/server.key\n"
 #endif
 	"\tstatic\t/\tpage\n"
 	"}\n";
 
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 static const char *dh2048_data =
 	"-----BEGIN DH PARAMETERS-----\n"
 	"MIIBCAKCAQEAn4f4Qn5SudFjEYPWTbUaOTLUH85YWmmPFW1+b5bRa9ygr+1wfamv\n"
@@ -277,7 +277,7 @@ cli_create(int argc, char **argv)
 
 	printf("%s created succesfully!\n", appl);
 
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	printf("note: do NOT use the created DH parameters/certificates in production\n");
 #endif
 }
@@ -766,7 +766,7 @@ cli_find_files(const char *path, void (*cb)(char *, struct dirent *))
 static void
 cli_generate_certs(void)
 {
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	BIGNUM			*e;
 	FILE			*fp;
 	time_t			now;

--- a/src/config.c
+++ b/src/config.c
@@ -302,7 +302,7 @@ configure_tls_cipher(char **argv)
 static int
 configure_tls_dhparam(char **argv)
 {
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	BIO		*bio;
 
 	if (argv[1] == NULL)

--- a/src/config.c
+++ b/src/config.c
@@ -302,7 +302,7 @@ configure_tls_cipher(char **argv)
 static int
 configure_tls_dhparam(char **argv)
 {
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	BIO		*bio;
 
 	if (argv[1] == NULL)

--- a/src/connection.c
+++ b/src/connection.c
@@ -101,7 +101,7 @@ kore_connection_accept(struct listener *l, struct connection **out)
 		return (KORE_RESULT_ERROR);
 	}
 
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	c->state = CONN_STATE_SSL_SHAKE;
 	c->write = net_write_ssl;
 	c->read = net_read_ssl;
@@ -141,7 +141,7 @@ kore_connection_disconnect(struct connection *c)
 int
 kore_connection_handle(struct connection *c)
 {
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	int			r;
 	u_int32_t		len;
 	const u_char		*data;
@@ -152,7 +152,7 @@ kore_connection_handle(struct connection *c)
 	kore_connection_stop_idletimer(c);
 
 	switch (c->state) {
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	case CONN_STATE_SSL_SHAKE:
 		if (c->ssl == NULL) {
 			c->ssl = SSL_new(primary_dom->ssl_ctx);
@@ -237,7 +237,7 @@ kore_connection_handle(struct connection *c)
 
 		c->state = CONN_STATE_ESTABLISHED;
 		/* FALLTHROUGH */
-#endif /* !KORE_NO_SSL */
+#endif /* !KORE_NO_TLS */
 	case CONN_STATE_ESTABLISHED:
 		if (c->flags & CONN_READ_POSSIBLE) {
 			if (!net_recv_flush(c))
@@ -270,7 +270,7 @@ kore_connection_remove(struct connection *c)
 
 	kore_debug("kore_connection_remove(%p)", c);
 
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	if (c->ssl != NULL) {
 		SSL_shutdown(c->ssl);
 		SSL_free(c->ssl);

--- a/src/connection.c
+++ b/src/connection.c
@@ -101,7 +101,7 @@ kore_connection_accept(struct listener *l, struct connection **out)
 		return (KORE_RESULT_ERROR);
 	}
 
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	c->state = CONN_STATE_SSL_SHAKE;
 	c->write = net_write_ssl;
 	c->read = net_read_ssl;
@@ -141,7 +141,7 @@ kore_connection_disconnect(struct connection *c)
 int
 kore_connection_handle(struct connection *c)
 {
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	int			r;
 	u_int32_t		len;
 	const u_char		*data;
@@ -152,7 +152,7 @@ kore_connection_handle(struct connection *c)
 	kore_connection_stop_idletimer(c);
 
 	switch (c->state) {
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	case CONN_STATE_SSL_SHAKE:
 		if (c->ssl == NULL) {
 			c->ssl = SSL_new(primary_dom->ssl_ctx);
@@ -237,7 +237,7 @@ kore_connection_handle(struct connection *c)
 
 		c->state = CONN_STATE_ESTABLISHED;
 		/* FALLTHROUGH */
-#endif /* !KORE_BENCHMARK */
+#endif /* !KORE_NO_SSL */
 	case CONN_STATE_ESTABLISHED:
 		if (c->flags & CONN_READ_POSSIBLE) {
 			if (!net_recv_flush(c))
@@ -270,7 +270,7 @@ kore_connection_remove(struct connection *c)
 
 	kore_debug("kore_connection_remove(%p)", c);
 
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	if (c->ssl != NULL) {
 		SSL_shutdown(c->ssl);
 		SSL_free(c->ssl);

--- a/src/domain.c
+++ b/src/domain.c
@@ -27,7 +27,7 @@ int				tls_version = KORE_TLS_VERSION_1_2;
 
 static void	domain_load_crl(struct kore_domain *);
 
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 static int	domain_x509_verify(int, X509_STORE_CTX *);
 #endif
 
@@ -67,7 +67,7 @@ kore_domain_new(char *domain)
 void
 kore_domain_sslstart(struct kore_domain *dom)
 {
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	STACK_OF(X509_NAME)	*certs;
 	X509_STORE		*store;
 	const SSL_METHOD	*method;
@@ -212,7 +212,7 @@ kore_domain_load_crl(void)
 static void
 domain_load_crl(struct kore_domain *dom)
 {
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	X509_STORE		*store;
 
 	ERR_clear_error();
@@ -241,7 +241,7 @@ domain_load_crl(struct kore_domain *dom)
 #endif
 }
 
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 static int
 domain_x509_verify(int ok, X509_STORE_CTX *ctx)
 {

--- a/src/domain.c
+++ b/src/domain.c
@@ -27,7 +27,7 @@ int				tls_version = KORE_TLS_VERSION_1_2;
 
 static void	domain_load_crl(struct kore_domain *);
 
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 static int	domain_x509_verify(int, X509_STORE_CTX *);
 #endif
 
@@ -67,7 +67,7 @@ kore_domain_new(char *domain)
 void
 kore_domain_sslstart(struct kore_domain *dom)
 {
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	STACK_OF(X509_NAME)	*certs;
 	X509_STORE		*store;
 	const SSL_METHOD	*method;
@@ -212,7 +212,7 @@ kore_domain_load_crl(void)
 static void
 domain_load_crl(struct kore_domain *dom)
 {
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	X509_STORE		*store;
 
 	ERR_clear_error();
@@ -241,7 +241,7 @@ domain_load_crl(struct kore_domain *dom)
 #endif
 }
 
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 static int
 domain_x509_verify(int ok, X509_STORE_CTX *ctx)
 {

--- a/src/kore.c
+++ b/src/kore.c
@@ -173,7 +173,7 @@ main(int argc, char *argv[])
 	return (0);
 }
 
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 int
 kore_tls_npn_cb(SSL *ssl, const u_char **data, unsigned int *len, void *arg)
 {
@@ -307,7 +307,7 @@ kore_signal(int sig)
 static void
 kore_server_sslstart(void)
 {
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 	kore_debug("kore_server_sslstart()");
 
 	SSL_library_init();

--- a/src/kore.c
+++ b/src/kore.c
@@ -173,7 +173,7 @@ main(int argc, char *argv[])
 	return (0);
 }
 
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 int
 kore_tls_npn_cb(SSL *ssl, const u_char **data, unsigned int *len, void *arg)
 {
@@ -307,7 +307,7 @@ kore_signal(int sig)
 static void
 kore_server_sslstart(void)
 {
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 	kore_debug("kore_server_sslstart()");
 
 	SSL_library_init();

--- a/src/net.c
+++ b/src/net.c
@@ -297,7 +297,7 @@ net_remove_netbuf(struct netbuf_head *list, struct netbuf *nb)
 	kore_pool_put(&nb_pool, nb);
 }
 
-#if !defined(KORE_BENCHMARK)
+#if !defined(KORE_NO_SSL)
 int
 net_write_ssl(struct connection *c, int len, int *written)
 {

--- a/src/net.c
+++ b/src/net.c
@@ -297,7 +297,7 @@ net_remove_netbuf(struct netbuf_head *list, struct netbuf *nb)
 	kore_pool_put(&nb_pool, nb);
 }
 
-#if !defined(KORE_NO_SSL)
+#if !defined(KORE_NO_TLS)
 int
 net_write_ssl(struct connection *c, int len, int *written)
 {


### PR DESCRIPTION
NO_SSL makes a bit more sense, especially for people who proxy their requests via nginx, apache, or similar.