### PR TITLE
Fix websockets. Connection must be Upgrade, not keep-alive, Upgrade

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -1251,7 +1251,7 @@ http_response_normal(struct http_request *req, struct connection *c,
 		if (req->owner->proto != CONN_PROTO_WEBSOCKET) {
 			kore_buf_appendf(header_buf, "connection: keep-alive\r\n");
 			kore_buf_appendf(header_buf, "keep-alive: timeout=%d\r\n",
-		    	http_keepalive_time);
+		    	    http_keepalive_time);
 		}
 	} else {
 		c->flags |= CONN_CLOSE_EMPTY;

--- a/src/http.c
+++ b/src/http.c
@@ -466,6 +466,7 @@ http_response(struct http_request *req, int status, void *d, u_int32_t l)
 		http_response_spdy(req, req->owner, req->stream, status, d, l);
 		break;
 	case CONN_PROTO_HTTP:
+	case CONN_PROTO_WEBSOCKET:
 		http_response_normal(req, req->owner, status, d, l);
 		break;
 	default:
@@ -1247,9 +1248,11 @@ http_response_normal(struct http_request *req, struct connection *c,
 	}
 
 	if (http_keepalive_time && connection_close == 0) {
-		kore_buf_appendf(header_buf, "connection: keep-alive\r\n");
-		kore_buf_appendf(header_buf, "keep-alive: timeout=%d\r\n",
-		    http_keepalive_time);
+		if (req->owner->proto != CONN_PROTO_WEBSOCKET) {
+			kore_buf_appendf(header_buf, "connection: keep-alive\r\n");
+			kore_buf_appendf(header_buf, "keep-alive: timeout=%d\r\n",
+		    	http_keepalive_time);
+		}
 	} else {
 		c->flags |= CONN_CLOSE_EMPTY;
 		kore_buf_appendf(header_buf, "connection: close\r\n");

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -98,12 +98,12 @@ kore_websocket_handshake(struct http_request *req, struct kore_wscbs *wscbs)
 
 	kore_debug("%p: new websocket connection", req->owner);
 
+	req->owner->proto = CONN_PROTO_WEBSOCKET;
 	http_response(req, HTTP_STATUS_SWITCHING_PROTOCOLS, NULL, 0);
 	net_recv_reset(req->owner, WEBSOCKET_FRAME_HDR, websocket_recv_opcode);
 
 	req->owner->disconnect = websocket_disconnect;
 	req->owner->rnb->flags &= ~NETBUF_CALL_CB_ALWAYS;
-	req->owner->proto = CONN_PROTO_WEBSOCKET;
 
 	req->owner->wscbs = wscbs;
 	req->owner->idle_timer.start = kore_time_ms();


### PR DESCRIPTION
For the websocket handshake, Safari and Chrome will not accept this:
connection: keep-alive, Upgrade
(OK for Firefox)
Do not append keep-alive for CONN_PROTO_WEBSOCKET
