### PR TITLE
Cleanup of TLS code if compiled with NOTLS=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 ifneq ("$(NOTLS)", "")
 	CFLAGS+=-DKORE_NO_TLS
-	LDFLAGS=-rdynamic -lz
+	LDFLAGS=-rdynamic -lcrypto -lz
 endif
 
 ifneq ("$(PGSQL)", "")

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 ifneq ("$(NOTLS)", "")
 	CFLAGS+=-DKORE_NO_TLS
-	LDFLAGS=-rdynamic -lz -lcrypto
+	LDFLAGS=-rdynamic -lz
 endif
 
 ifneq ("$(PGSQL)", "")

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -27,17 +27,11 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#include <openssl/ssl.h>
+
 #if !defined(KORE_NO_TLS)
 #include <openssl/err.h>
 #include <openssl/dh.h>
-#include <openssl/ssl.h>
-#else
-#include <sys/time.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
-#include <time.h>
 #endif
 
 #include <errno.h>

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -27,9 +27,18 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#if !defined(KORE_NO_TLS)
 #include <openssl/err.h>
 #include <openssl/dh.h>
 #include <openssl/ssl.h>
+#else
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <time.h>
+#endif
 
 #include <errno.h>
 #include <regex.h>
@@ -180,10 +189,12 @@ struct connection {
 	u_int8_t		state;
 	u_int8_t		proto;
 	void			*owner;
+#if !defined(KORE_NO_TLS)
 	SSL			*ssl;
+	X509			*cert;
+#endif
 	u_int8_t		flags;
 	void			*hdlr_extra;
-	X509			*cert;
 	void			*wscbs;
 	int			tls_reneg;
 
@@ -297,7 +308,9 @@ struct kore_domain {
 	char					*cafile;
 	char					*crlfile;
 	int					accesslog;
+#if !defined(KORE_NO_TLS)
 	SSL_CTX					*ssl_ctx;
+#endif
 	TAILQ_HEAD(, kore_module_handle)	handlers;
 	TAILQ_ENTRY(kore_domain)		list;
 };
@@ -391,7 +404,9 @@ extern char	*kore_pidfile;
 extern char	*config_file;
 extern char	*kore_tls_cipher_list;
 extern int	tls_version;
+#if !defined(KORE_NO_TLS)
 extern DH	*tls_dhparam;
+#endif
 
 extern u_int8_t			nlisteners;
 extern u_int64_t		spdy_idle_time;
@@ -452,10 +467,12 @@ void		kore_timer_remove(struct kore_timer *);
 struct kore_timer	*kore_timer_add(void (*cb)(void *, u_int64_t),
 			    u_int64_t, void *, int);
 
-int		kore_tls_sni_cb(SSL *, int *, void *);
 int		kore_server_bind(const char *, const char *);
+#if !defined(KORE_NO_TLS)
+int		kore_tls_sni_cb(SSL *, int *, void *);
 int		kore_tls_npn_cb(SSL *, const u_char **, unsigned int *, void *);
 void		kore_tls_info_callback(const SSL *, int, int);
+#endif
 
 void			kore_connection_init(void);
 void			kore_connection_prune(int);

--- a/src/accesslog.c
+++ b/src/accesslog.c
@@ -32,7 +32,9 @@ struct kore_log_packet {
 	char		host[KORE_DOMAINNAME_LEN];
 	char		path[HTTP_URI_LEN];
 	char		agent[HTTP_USERAGENT_LEN];
+#if !defined(KORE_NO_TLS)
 	char		cn[X509_CN_LENGTH];
+#endif
 };
 
 void
@@ -90,9 +92,11 @@ kore_accesslog_write(const void *data, u_int32_t len)
 		break;
 	}
 
+#if !defined(KORE_NO_TLS)
 	if (logpacket.cn[0] != '\0')
 		cn = logpacket.cn;
 	else
+#endif
 		cn = "none";
 
 	if (inet_ntop(logpacket.addrtype, &(logpacket.addr),
@@ -157,8 +161,8 @@ kore_accesslog(struct http_request *req)
 		    sizeof(logpacket.agent));
 	}
 
-	memset(logpacket.cn, '\0', sizeof(logpacket.cn));
 #if !defined(KORE_NO_TLS)
+	memset(logpacket.cn, '\0', sizeof(logpacket.cn));
 	if (req->owner->cert != NULL) {
 		if (X509_GET_CN(req->owner->cert,
 		    logpacket.cn, sizeof(logpacket.cn)) == -1) {

--- a/src/connection.c
+++ b/src/connection.c
@@ -45,11 +45,13 @@ kore_connection_new(void *owner)
 
 	c = kore_pool_get(&connection_pool);
 
+#if !defined(KORE_NO_TLS)
 	c->ssl = NULL;
+	c->cert = NULL;
+#endif
 	c->flags = 0;
 	c->rnb = NULL;
 	c->snb = NULL;
-	c->cert = NULL;
 	c->wscbs = NULL;
 	c->owner = owner;
 	c->tls_reneg = 0;

--- a/src/domain.c
+++ b/src/domain.c
@@ -22,8 +22,10 @@
 
 struct kore_domain_h		domains;
 struct kore_domain		*primary_dom = NULL;
+#if !defined(KORE_NO_TLS)
 DH				*tls_dhparam = NULL;
 int				tls_version = KORE_TLS_VERSION_1_2;
+#endif
 
 static void	domain_load_crl(struct kore_domain *);
 
@@ -49,11 +51,13 @@ kore_domain_new(char *domain)
 
 	dom = kore_malloc(sizeof(*dom));
 	dom->accesslog = -1;
+#if !defined(KORE_NO_TLS)
 	dom->cafile = NULL;
 	dom->certkey = NULL;
 	dom->ssl_ctx = NULL;
 	dom->certfile = NULL;
 	dom->crlfile = NULL;
+#endif
 	dom->domain = kore_strdup(domain);
 	TAILQ_INIT(&(dom->handlers));
 	TAILQ_INSERT_TAIL(&domains, dom, list);

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -48,11 +48,9 @@ static void	websocket_frame_build(struct kore_buf *, u_int8_t,
 void
 kore_websocket_handshake(struct http_request *req, struct kore_wscbs *wscbs)
 {
-#if !defined(KORE_NO_TLS)
 	SHA_CTX			sctx;
 	char			*base64;
 	u_int8_t		digest[SHA_DIGEST_LENGTH];
-#endif
 	struct kore_buf		*buf;
 	char			*key, *version;
 
@@ -82,28 +80,22 @@ kore_websocket_handshake(struct http_request *req, struct kore_wscbs *wscbs)
 	kore_buf_appendf(buf, "%s%s", key, WEBSOCKET_SERVER_RESPONSE);
 	kore_mem_free(key);
 
-#if !defined(KORE_NO_TLS)
 	(void)SHA1_Init(&sctx);
 	(void)SHA1_Update(&sctx, buf->data, buf->offset);
 	(void)SHA1_Final(digest, &sctx);
-#endif
 
 	kore_buf_free(buf);
 
-#if !defined(KORE_NO_TLS)
 	if (!kore_base64_encode(digest, sizeof(digest), &base64)) {
 		kore_debug("failed to base64 encode digest");
 		http_response(req, HTTP_STATUS_INTERNAL_ERROR, NULL, 0);
 		return;
 	}
-#endif
 
 	http_response_header(req, "upgrade", "websocket");
 	http_response_header(req, "connection", "upgrade");
-#if !defined(KORE_NO_TLS)
 	http_response_header(req, "sec-websocket-accept", base64);
 	kore_mem_free(base64);
-#endif
 
 	kore_debug("%p: new websocket connection", req->owner);
 


### PR DESCRIPTION
Fixes #76 - This PR removes all TLS code if compiled with NOTLS=1 by including KORE_NO_TLS flags where necessary.