### PR TITLE
Add resource management as part of the kore shutdown process.

### DIFF
--- a/includes/http.h
+++ b/includes/http.h
@@ -215,6 +215,7 @@ extern u_int16_t	http_keepalive_time;
 extern u_int32_t	http_request_limit;
 
 void		http_init(void);
+void		http_fini(void);
 void		http_process(void);
 const char	*http_status_text(int);
 time_t		http_date_to_time(char *);

--- a/includes/http.h
+++ b/includes/http.h
@@ -215,7 +215,7 @@ extern u_int16_t	http_keepalive_time;
 extern u_int32_t	http_request_limit;
 
 void		http_init(void);
-void		http_fini(void);
+void		http_cleanup(void);
 void		http_process(void);
 const char	*http_status_text(int);
 time_t		http_date_to_time(char *);

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -35,6 +35,7 @@
 #include <regex.h>
 #include <syslog.h>
 #include <unistd.h>
+#include <stdarg.h>
 
 #if defined(__cplusplus)
 extern "C" {

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -420,7 +420,7 @@ struct kore_worker	*kore_worker_data(u_int8_t);
 
 void		kore_platform_init(void);
 void		kore_platform_event_init(void);
-void		kore_platform_event_fini(void);
+void		kore_platform_event_cleanup(void);
 void		kore_platform_proctitle(char *);
 void		kore_platform_disable_read(int);
 void		kore_platform_enable_accept(void);
@@ -454,7 +454,7 @@ int		kore_server_bind(const char *, const char *, const char *);
 void		kore_tls_info_callback(const SSL *, int, int);
 
 void			kore_connection_init(void);
-void			kore_connection_fini(void);
+void			kore_connection_cleanup(void);
 void			kore_connection_prune(int);
 struct connection	*kore_connection_new(void *);
 void			kore_connection_check_timeout(void);
@@ -483,7 +483,7 @@ void		*kore_pool_get(struct kore_pool *);
 void		kore_pool_put(struct kore_pool *, void *);
 void		kore_pool_init(struct kore_pool *, const char *,
 		    u_int32_t, u_int32_t);
-void		kore_pool_fini(struct kore_pool *);
+void		kore_pool_cleanup(struct kore_pool *);
 
 time_t		kore_date_to_time(char *);
 char		*kore_time_to_date(time_t);
@@ -557,7 +557,7 @@ void		net_write32(u_int8_t *, u_int32_t);
 void		net_write64(u_int8_t *, u_int64_t);
 
 void		net_init(void);
-void		net_fini(void);
+void		net_cleanup(void);
 int		net_send(struct connection *);
 int		net_send_flush(struct connection *);
 int		net_recv_flush(struct connection *);

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -420,6 +420,7 @@ struct kore_worker	*kore_worker_data(u_int8_t);
 
 void		kore_platform_init(void);
 void		kore_platform_event_init(void);
+void		kore_platform_event_fini(void);
 void		kore_platform_proctitle(char *);
 void		kore_platform_disable_read(int);
 void		kore_platform_enable_accept(void);
@@ -453,6 +454,7 @@ int		kore_server_bind(const char *, const char *, const char *);
 void		kore_tls_info_callback(const SSL *, int, int);
 
 void			kore_connection_init(void);
+void			kore_connection_fini(void);
 void			kore_connection_prune(int);
 struct connection	*kore_connection_new(void *);
 void			kore_connection_check_timeout(void);
@@ -481,6 +483,7 @@ void		*kore_pool_get(struct kore_pool *);
 void		kore_pool_put(struct kore_pool *, void *);
 void		kore_pool_init(struct kore_pool *, const char *,
 		    u_int32_t, u_int32_t);
+void		kore_pool_fini(struct kore_pool *);
 
 time_t		kore_date_to_time(char *);
 char		*kore_time_to_date(time_t);
@@ -554,6 +557,7 @@ void		net_write32(u_int8_t *, u_int32_t);
 void		net_write64(u_int8_t *, u_int64_t);
 
 void		net_init(void);
+void		net_fini(void);
 int		net_send(struct connection *);
 int		net_send_flush(struct connection *);
 int		net_recv_flush(struct connection *);

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -535,7 +535,9 @@ int		kore_msg_register(u_int8_t,
 		    void (*cb)(struct kore_msg *, const void *));
 
 void		kore_domain_init(void);
+void		kore_domain_cleanup(void);
 int		kore_domain_new(char *);
+void		kore_domain_free(struct kore_domain *);
 void		kore_module_init(void);
 void		kore_module_reload(int);
 void		kore_module_onload(void);
@@ -547,6 +549,7 @@ void		kore_module_load(const char *, const char *);
 void		kore_domain_sslstart(struct kore_domain *);
 int		kore_module_handler_new(const char *, const char *,
 		    const char *, const char *, int);
+void		kore_module_handler_free(struct kore_module_handle *);
 
 struct kore_domain		*kore_domain_lookup(const char *);
 struct kore_module_handle	*kore_module_handler_find(const char *,

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -94,6 +94,20 @@ kore_platform_event_init(void)
 	}
 }
 
+void
+kore_platform_event_cleanup(void)
+{
+	if (kfd >= 0) {
+		close(kfd);
+		kfd = -1;
+	}
+
+	if (events != NULL) {
+		kore_mem_free(events);
+		events = NULL;
+	}
+}
+
 int
 kore_platform_event_wait(u_int64_t timer)
 {

--- a/src/bsd.c
+++ b/src/bsd.c
@@ -22,6 +22,9 @@
 #include <sys/cpuset.h>
 #endif
 
+#include <errno.h>
+#include <string.h>
+
 #include "kore.h"
 
 #if defined(KORE_USE_PGSQL)

--- a/src/buf.c
+++ b/src/buf.c
@@ -14,6 +14,11 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+
 #include "kore.h"
 
 struct kore_buf *

--- a/src/cli.c
+++ b/src/cli.c
@@ -20,6 +20,7 @@
 #include <sys/queue.h>
 #include <sys/wait.h>
 #include <sys/mman.h>
+#include <sys/time.h>
 
 #include <openssl/pem.h>
 #include <openssl/x509v3.h>

--- a/src/config.c
+++ b/src/config.c
@@ -16,6 +16,8 @@
 
 #include <sys/stat.h>
 
+#include <stdio.h>
+#include <string.h>
 #include <ctype.h>
 #include <limits.h>
 #include <fcntl.h>

--- a/src/connection.c
+++ b/src/connection.c
@@ -39,13 +39,13 @@ kore_connection_init(void)
 }
 
 void
-kore_connection_fini(void)
+kore_connection_cleanup(void)
 {
-	kore_debug("connection_fini()");
+	kore_debug("connection_cleanup()");
 
 	/* Drop all connections */
 	kore_connection_prune(KORE_CONNECTION_PRUNE_ALL);
-	kore_pool_fini(&connection_pool);
+	kore_pool_cleanup(&connection_pool);
 }
 
 struct connection *

--- a/src/connection.c
+++ b/src/connection.c
@@ -38,6 +38,16 @@ kore_connection_init(void)
 	    sizeof(struct connection), worker_max_connections);
 }
 
+void
+kore_connection_fini(void)
+{
+	kore_debug("connection_fini()");
+
+	/* Drop all connections */
+	kore_connection_prune(KORE_CONNECTION_PRUNE_ALL);
+	kore_pool_fini(&connection_pool);
+}
+
 struct connection *
 kore_connection_new(void *owner)
 {

--- a/src/domain.c
+++ b/src/domain.c
@@ -42,6 +42,17 @@ kore_domain_init(void)
 	TAILQ_INIT(&domains);
 }
 
+void
+kore_domain_cleanup(void)
+{
+	struct kore_domain *dom;
+
+	while ((dom=TAILQ_FIRST(&domains)) != NULL) {
+		TAILQ_REMOVE(&domains, dom, list);
+		kore_domain_free(dom);
+	}
+}
+
 int
 kore_domain_new(char *domain)
 {
@@ -69,6 +80,49 @@ kore_domain_new(char *domain)
 		primary_dom = dom;
 
 	return (KORE_RESULT_OK);
+}
+
+void
+kore_domain_free(struct kore_domain *dom)
+{
+	struct kore_module_handle *hdlr;
+
+	if (dom != NULL) {
+
+		if (primary_dom == dom) {
+			primary_dom = NULL;
+		}
+		TAILQ_REMOVE(&domains, dom, list);
+
+		if (dom->domain != NULL) {
+			kore_mem_free(dom->domain);
+		}
+
+#if !defined(KORE_NO_TLS)
+		if (dom->ssl_ctx != NULL) {
+			SSL_CTX_free(dom->ssl_ctx);
+		}
+		if (dom->cafile != NULL) {
+			kore_mem_free(dom->cafile);
+		}
+		if (dom->certkey != NULL) {
+			kore_mem_free(dom->certkey);
+		}
+		if (dom->certfile != NULL) {
+			kore_mem_free(dom->certfile);
+		}
+		if (dom->crlfile != NULL) {
+			kore_mem_free(dom->crlfile);
+		}
+#endif
+
+		/* Drop all handlers associated with this domain */
+		while ((hdlr=TAILQ_FIRST(&(dom->handlers))) != NULL) {
+			TAILQ_REMOVE(&(dom->handlers), hdlr, list);
+			kore_module_handler_free(hdlr);
+		}
+		kore_mem_free(dom);
+	}
 }
 
 void
@@ -179,7 +233,9 @@ kore_domain_sslstart(struct kore_domain *dom)
 	SSL_CTX_set_tlsext_servername_callback(dom->ssl_ctx, kore_tls_sni_cb);
 
 	kore_mem_free(dom->certfile);
+	dom->certfile = NULL;
 	kore_mem_free(dom->certkey);
+	dom->certkey = NULL;
 #endif
 }
 

--- a/src/http.c
+++ b/src/http.c
@@ -87,17 +87,17 @@ http_init(void)
 }
 
 void
-http_fini(void)
+http_cleanup(void)
 {
 	if (header_buf != NULL) {
 		kore_buf_free(header_buf);
 		header_buf = NULL;
 	}
 
-	kore_pool_fini(&http_request_pool);
-	kore_pool_fini(&http_header_pool);
-	kore_pool_fini(&http_host_pool);
-	kore_pool_fini(&http_path_pool);
+	kore_pool_cleanup(&http_request_pool);
+	kore_pool_cleanup(&http_header_pool);
+	kore_pool_cleanup(&http_host_pool);
+	kore_pool_cleanup(&http_path_pool);
 }
 
 int

--- a/src/http.c
+++ b/src/http.c
@@ -86,6 +86,20 @@ http_init(void)
 	    "http_path_pool", HTTP_URI_LEN, prealloc);
 }
 
+void
+http_fini(void)
+{
+	if (header_buf != NULL) {
+		kore_buf_free(header_buf);
+		header_buf = NULL;
+	}
+
+	kore_pool_fini(&http_request_pool);
+	kore_pool_fini(&http_header_pool);
+	kore_pool_fini(&http_host_pool);
+	kore_pool_fini(&http_path_pool);
+}
+
 int
 http_request_new(struct connection *c, const char *host,
     const char *method, const char *path, const char *version,

--- a/src/http.c
+++ b/src/http.c
@@ -115,6 +115,7 @@ http_cleanup(void)
 	kore_pool_cleanup(&http_header_pool);
 	kore_pool_cleanup(&http_host_pool);
 	kore_pool_cleanup(&http_path_pool);
+	kore_pool_cleanup(&http_body_path);
 }
 
 int

--- a/src/http.c
+++ b/src/http.c
@@ -18,6 +18,8 @@
 
 #include <ctype.h>
 #include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "kore.h"
 #include "http.h"

--- a/src/kore.c
+++ b/src/kore.c
@@ -402,6 +402,10 @@ kore_server_start(void)
 		kore_platform_event_wait(100);
 		kore_connection_prune(KORE_CONNECTION_PRUNE_DISCONNECT);
 	}
+
+	kore_platform_event_fini();
+	kore_connection_fini();
+	net_fini();
 }
 
 static void

--- a/src/kore.c
+++ b/src/kore.c
@@ -403,9 +403,9 @@ kore_server_start(void)
 		kore_connection_prune(KORE_CONNECTION_PRUNE_DISCONNECT);
 	}
 
-	kore_platform_event_fini();
-	kore_connection_fini();
-	net_fini();
+	kore_platform_event_cleanup();
+	kore_connection_cleanup();
+	net_cleanup();
 }
 
 static void

--- a/src/kore.c
+++ b/src/kore.c
@@ -421,6 +421,7 @@ kore_server_start(void)
 
 	kore_platform_event_cleanup();
 	kore_connection_cleanup();
+        kore_domain_cleanup();
 	net_cleanup();
 }
 

--- a/src/kore.c
+++ b/src/kore.c
@@ -18,6 +18,7 @@
 #include <sys/socket.h>
 #include <sys/resource.h>
 
+#include <stdio.h>
 #include <netdb.h>
 #include <signal.h>
 

--- a/src/linux.c
+++ b/src/linux.c
@@ -72,7 +72,7 @@ kore_platform_event_init(void)
 }
 
 void
-kore_platform_event_fini(void)
+kore_platform_event_cleanup(void)
 {
 	if (efd >= 0) {
 		close(efd);

--- a/src/linux.c
+++ b/src/linux.c
@@ -71,6 +71,20 @@ kore_platform_event_init(void)
 	events = kore_calloc(event_count, sizeof(struct epoll_event));
 }
 
+void
+kore_platform_event_fini(void)
+{
+	if (efd >= 0) {
+		close(efd);
+		efd = -1;
+	}
+
+	if (events != NULL) {
+		kore_mem_free(events);
+		events = NULL;
+	}
+}
+
 int
 kore_platform_event_wait(u_int64_t timer)
 {

--- a/src/mem.c
+++ b/src/mem.c
@@ -89,19 +89,12 @@ kore_realloc(void *ptr, size_t len)
 void *
 kore_calloc(size_t memb, size_t len)
 {
-	void *result;
-	const size_t nbytes = memb * len;
-
-	if (nbytes == 0)
+	if (memb == 0 || len == 0)
 		fatal("kore_calloc(): zero size");
-	if (nbytes > SIZE_MAX)
+	if (SIZE_MAX / memb < len)
 		fatal("kore_calloc: memb * len > SIZE_MAX");
-	
-	result = kore_malloc(nbytes);
-	if (result == NULL)
-		fatal("kore_calloc: alloc failed for %zd bytes", nbytes);
 
-	return (result);
+	return (kore_malloc(memb * len));
 }
 
 void

--- a/src/mem.c
+++ b/src/mem.c
@@ -50,7 +50,7 @@ kore_malloc(size_t len)
 
 	mlen = sizeof(u_int32_t) + len + sizeof(struct meminfo);
 	if ((ptr = calloc(1, mlen)) == NULL)
-		fatal("kore_malloc(%d): %d", len, errno);
+		fatal("kore_malloc(%zd): %d", len, errno);
 
 	plen = (u_int32_t *)ptr;
 	*plen = len;
@@ -89,12 +89,19 @@ kore_realloc(void *ptr, size_t len)
 void *
 kore_calloc(size_t memb, size_t len)
 {
-	if (memb == 0 || len == 0)
-		fatal("kore_calloc(): zero size");
-	if (SIZE_MAX / memb < len)
-		fatal("kore_calloc: memb * len > SIZE_MAX");
+	void *result;
+	const size_t nbytes = memb * len;
 
-	return (kore_malloc(memb * len));
+	if (nbytes == 0)
+		fatal("kore_calloc(): zero size");
+	if (nbytes > SIZE_MAX)
+		fatal("kore_calloc: memb * len > SIZE_MAX");
+	
+	result = kore_malloc(nbytes);
+	if (result == NULL)
+		fatal("kore_calloc: alloc failed for %zd bytes", nbytes);
+
+	return (result);
 }
 
 void

--- a/src/net.c
+++ b/src/net.c
@@ -37,6 +37,13 @@ net_init(void)
 }
 
 void
+net_fini(void)
+{
+	kore_debug("net_fini()");
+	kore_pool_fini(&nb_pool);
+}
+
+void
 net_send_queue(struct connection *c, const void *data, u_int32_t len)
 {
 	const u_int8_t		*d;

--- a/src/net.c
+++ b/src/net.c
@@ -61,7 +61,7 @@ net_send_queue(struct connection *c, const void *data, u_int32_t len)
 			memcpy(nb->buf + nb->b_len, d, len);
 			nb->b_len += len;
 			return;
-		} else if (len > avail) {
+		} else {
 			memcpy(nb->buf + nb->b_len, d, avail);
 			nb->b_len += avail;
 

--- a/src/net.c
+++ b/src/net.c
@@ -37,10 +37,10 @@ net_init(void)
 }
 
 void
-net_fini(void)
+net_cleanup(void)
 {
-	kore_debug("net_fini()");
-	kore_pool_fini(&nb_pool);
+	kore_debug("net_cleanup()");
+	kore_pool_cleanup(&nb_pool);
 }
 
 void

--- a/src/pool.c
+++ b/src/pool.c
@@ -43,7 +43,7 @@ kore_pool_init(struct kore_pool *pool, const char *name,
 }
 
 void
-kore_pool_fini(struct kore_pool *pool)
+kore_pool_cleanup(struct kore_pool *pool)
 {
 	if (pool->inuse)
 		kore_debug("Pool %s: destroyed with %u allocs in use", 

--- a/src/pool.c
+++ b/src/pool.c
@@ -22,6 +22,7 @@
 #define POOL_ELEMENT_FREE		1
 
 static void		pool_region_create(struct kore_pool *, u_int32_t);
+static void		pool_region_destroy(struct kore_pool *);
 
 void
 kore_pool_init(struct kore_pool *pool, const char *name,
@@ -39,6 +40,27 @@ kore_pool_init(struct kore_pool *pool, const char *name,
 	LIST_INIT(&(pool->freelist));
 
 	pool_region_create(pool, elm);
+}
+
+void
+kore_pool_fini(struct kore_pool *pool)
+{
+	if (pool->inuse)
+		kore_debug("Pool %s: destroyed with %u allocs in use", 
+			pool->name ? pool->name : "<unknown>",
+			pool->inuse );
+
+	pool->elms = 0;
+	pool->inuse = 0;
+	pool->elen = 0;
+	pool->slen = 0;
+
+	if (pool->name != NULL) {
+		kore_mem_free(pool->name);
+		pool->name = NULL;
+	}
+
+	pool_region_destroy(pool);
 }
 
 void *
@@ -110,4 +132,24 @@ pool_region_create(struct kore_pool *pool, u_int32_t elms)
 	}
 
 	pool->elms += elms;
+}
+
+static void
+pool_region_destroy(struct kore_pool *pool)
+{
+	struct kore_pool_region	*reg;
+
+	kore_debug("pool_region_destroy(%p)", pool);
+
+	/* Take care iterating when modifying list contents */
+	while (!LIST_EMPTY(&pool->regions)) {
+		reg = LIST_FIRST(&pool->regions);
+		LIST_REMOVE(reg, list);
+		kore_mem_free(reg->start);
+		kore_mem_free(reg);
+	}
+
+	/* Freelist references into the regions memory allocations */
+	LIST_INIT(&pool->freelist);
+	pool->elms = 0;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -16,6 +16,10 @@
 
 #include <sys/time.h>
 
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
 #include <limits.h>
 
 #include "kore.h"

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -17,6 +17,7 @@
 #include <sys/param.h>
 
 #include <limits.h>
+#include <string.h>
 
 #include "kore.h"
 #include "http.h"

--- a/src/worker.c
+++ b/src/worker.c
@@ -370,6 +370,7 @@ kore_worker_entry(struct kore_worker *kw)
 
 	kore_platform_event_cleanup();
 	kore_connection_cleanup();
+	kore_domain_cleanup();
 #if !defined(KORE_NO_HTTP)
 	http_cleanup();
 #endif

--- a/src/worker.c
+++ b/src/worker.c
@@ -355,7 +355,12 @@ kore_worker_entry(struct kore_worker *kw)
 #endif
 	}
 
-	kore_connection_prune(KORE_CONNECTION_PRUNE_ALL);
+	kore_platform_event_fini();
+	kore_connection_fini();
+#if !defined(KORE_NO_HTTP)
+	http_fini();
+#endif
+	net_fini();
 	kore_debug("worker %d shutting down", kw->id);
 	exit(0);
 }

--- a/src/worker.c
+++ b/src/worker.c
@@ -355,12 +355,12 @@ kore_worker_entry(struct kore_worker *kw)
 #endif
 	}
 
-	kore_platform_event_fini();
-	kore_connection_fini();
+	kore_platform_event_cleanup();
+	kore_connection_cleanup();
 #if !defined(KORE_NO_HTTP)
-	http_fini();
+	http_cleanup();
 #endif
-	net_fini();
+	net_cleanup();
 	kore_debug("worker %d shutting down", kw->id);
 	exit(0);
 }


### PR DESCRIPTION
Hi Joris - 

What a neat codebase you have created.  I added some management of buffers and file descriptors on shutdown.  This was to get Kore more clean when running under Valgrind.  I haven't touched anything related to memory management during the config parsing and validation process - from the comments it looks like you're planning to rework this at some point anyway?

Thanks and best wishes
Stig