### PR TITLE
Fix off-by-one error when reallocing buffer

### DIFF
--- a/src/buf.c
+++ b/src/buf.c
@@ -32,7 +32,7 @@ kore_buf_create(u_int32_t initial)
 void
 kore_buf_append(struct kore_buf *buf, const void *d, u_int32_t len)
 {
-	if ((buf->offset + len) >= buf->length) {
+	if ((buf->offset + len) > buf->length) {
 		buf->length += len + KORE_BUF_INCREMENT;
 		buf->data = kore_realloc(buf->data, buf->length);
 	}


### PR DESCRIPTION
There was an invalid boundary check when appending to a buffer. The consequence of this was that the POST data buffer was deterministically realloced.

I noticed this when debugging the memory usage for multipart post requests. I've created a small example that shows the error, see [my memory debug branch](https://github.com/CarlEkerot/kore/tree/ce-mem-debug).

To run it, start a server in debug mode, and send an arbitrary multipart POST request with the tool of your choice, for example:
```
curl -v -k -F file=@filename -H "Content-Length: 100000" https://127.0.0.1:8888/
```

On the server side, this yields:
```
[8983] src/mem.c:42 - [src/buf.c:25] Mallocing 100000 bytes
[8983] src/buf.c:36 - buf->offset: 0, len: 0, buf->length: 100000
.
.
.
[8983] src/buf.c:36 - buf->offset: 98456, len: 1544, buf->length: 100000
[8983] src/mem.c:70 - [src/buf.c:40] Reallocing 101672 bytes
```

This realloc should not be needed, as the buffer is sufficiently large. 