### PR TITLE
if read/write  return EINTR,retry

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -334,6 +334,8 @@ net_write(struct connection *c, int len, int *written)
 	if (r <= -1) {
 		switch (errno) {
 		case EINTR:
+			*written = 0;
+			return (KORE_RESULT_OK);
 		case EAGAIN:
 			c->flags &= ~CONN_WRITE_POSSIBLE;
 			return (KORE_RESULT_OK);
@@ -357,6 +359,8 @@ net_read(struct connection *c, int *bytes)
 	if (r <= 0) {
 		switch (errno) {
 		case EINTR:
+			*bytes = 0;
+			return (KORE_RESULT_OK);
 		case EAGAIN:
 			c->flags &= ~CONN_READ_POSSIBLE;
 			return (KORE_RESULT_OK);


### PR DESCRIPTION
Hi Joris,
If read/write is interrupted by signal before any bytes read, current behavior is giving up read/write operation. what i understand, with EPOLLET set on linux, it may lose the chance to read the socket buffer if it's last packet coming in. my change is to return OK and let the caller retry.  Could I have your comments, thanks.

Regards,
Ansen
