### PR TITLE
worker inherits a copy of parent's signal handler

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -264,14 +264,6 @@ kore_worker_entry(struct kore_worker *kw)
 	kore_pid = kw->pid;
 
 	sig_recv = 0;
-	signal(SIGHUP, kore_signal);
-	signal(SIGQUIT, kore_signal);
-	signal(SIGPIPE, SIG_IGN);
-
-	if (foreground)
-		signal(SIGINT, kore_signal);
-	else
-		signal(SIGINT, SIG_IGN);
 
 	net_init();
 #if !defined(KORE_NO_HTTP)


### PR DESCRIPTION
Hi Joris,
child worker process inherits a copy of parent's signal handler here, so here we don't need to redo it again. I had a test on Linux basis, The behavior is the same as before after the code removed.

Regards,
Ansen