### PR TITLE
avoid memory copy from net recv buf to http_body kore buf

### DIFF
--- a/includes/kore.h
+++ b/includes/kore.h
@@ -588,6 +588,9 @@ int		net_write(struct connection *, int, int *);
 int		net_write_ssl(struct connection *, int, int *);
 void		net_recv_reset(struct connection *, u_int32_t,
 		    int (*cb)(struct netbuf *));
+void            net_recv_cut(struct connection *c, u_int32_t offset,
+                u_int32_t cut_len, u_int32_t len, int (*cb)(struct netbuf *));
+struct kore_buf * net_buf_release_to_kore_buf(struct connection *c);
 void		net_remove_netbuf(struct netbuf_head *, struct netbuf *);
 void		net_recv_queue(struct connection *, u_int32_t, int,
 		    int (*cb)(struct netbuf *));

--- a/src/http.c
+++ b/src/http.c
@@ -708,23 +708,22 @@ http_header_recv(struct netbuf *nb)
 			    bytes_left, req->content_length, nb->s_off, len);
                         if(req->http_body_fd != -1){
 				net_recv_reset(c,
-			    	MIN(bytes_left, NETBUF_SEND_PAYLOAD_MAX),
-			    	http_body_recv);
+				MIN(bytes_left, NETBUF_SEND_PAYLOAD_MAX),
+				http_body_recv);
 			} else { 
-                                net_recv_cut(c,(end_headers - nb->buf), (nb->s_off - len), 
-                                req->content_length, http_body_recv);
-                                
-  		                c->rnb->flags &= ~NETBUF_CALL_CB_ALWAYS;
+				net_recv_cut(c,(end_headers - nb->buf), (nb->s_off - len), 
+				req->content_length, http_body_recv);
+				c->rnb->flags &= ~NETBUF_CALL_CB_ALWAYS;
 			}
-                        c->rnb->extra = req;
+			c->rnb->extra = req;
 			http_request_sleep(req);              
 		} else if (bytes_left == 0) {
 			req->flags |= HTTP_REQUEST_COMPLETE;
 			req->flags &= ~HTTP_REQUEST_EXPECT_BODY;
                         if(req->http_body_fd == -1){
-                        	req->http_body = kore_buf_create(req->content_length);
-                        	kore_buf_append(req->http_body, end_headers,
-                        	(nb->s_off - len));
+				req->http_body = kore_buf_create(req->content_length);
+				kore_buf_append(req->http_body, end_headers,
+				(nb->s_off - len));
                         }   
 			if (!http_body_rewind(req)) {
 				req->flags |= HTTP_REQUEST_DELETE;
@@ -1326,12 +1325,12 @@ http_body_recv(struct netbuf *nb)
 			http_error_response(req->owner, 500);
 			return (KORE_RESULT_ERROR);
 		}
-                req->content_length -= nb->s_off;
+		req->content_length -= nb->s_off;
 	} else if (req->content_length == nb->s_off) {
-                req->content_length = 0;
-                /*release recv buf to kore buf*/
-                req->http_body = net_buf_release_to_kore_buf(req->owner);
-                nb->flags |= NETBUF_CALL_CB_ALWAYS;
+		req->content_length = 0;
+		/*release recv buf to kore buf*/
+		req->http_body = net_buf_release_to_kore_buf(req->owner);
+		nb->flags |= NETBUF_CALL_CB_ALWAYS;
                 
 	} else {
 		req->flags |= HTTP_REQUEST_DELETE;

--- a/src/net.c
+++ b/src/net.c
@@ -139,28 +139,29 @@ net_recv_reset(struct connection *c, u_int32_t len, int (*cb)(struct netbuf *))
 void 
 net_recv_cut(struct connection *c, u_int32_t offset, u_int32_t cut_len, u_int32_t len,int (*cb)(struct netbuf *))
 {
-    memcpy(c->rnb->buf, c->rnb->buf+offset, cut_len);
-    c->rnb->s_off = cut_len;
-    c->rnb->b_len = len;
-    c->rnb->cb = cb;
-    if (c->rnb->b_len <= c->rnb->m_len)
-         return;
-    c->rnb->buf = kore_realloc(c->rnb->buf, c->rnb->b_len);
+	memcpy(c->rnb->buf, c->rnb->buf+offset, cut_len);
+	c->rnb->s_off = cut_len;
+	c->rnb->b_len = len;
+	c->rnb->cb = cb;
+	if (c->rnb->b_len <= c->rnb->m_len)
+		return;
+
+	c->rnb->buf = kore_realloc(c->rnb->buf, c->rnb->b_len);
 }
 
 struct kore_buf *
 net_buf_release_to_kore_buf(struct connection *c)
 {
-        struct kore_buf		*buf;
+	struct kore_buf		*buf;
 	
-        buf = kore_malloc(sizeof(*buf));
+	buf = kore_malloc(sizeof(*buf));
 	buf->data = c->rnb->buf ;
 	buf->length = c->rnb->m_len;
 	buf->offset = c->rnb->s_off;
 
-        c->rnb->s_off = 0;
-        c->rnb->buf = kore_malloc(c->rnb->m_len);
-        return (buf);
+	c->rnb->s_off = 0;
+	c->rnb->buf = kore_malloc(c->rnb->m_len);
+	return (buf);
 }
 
 void

--- a/src/net.c
+++ b/src/net.c
@@ -136,6 +136,33 @@ net_recv_reset(struct connection *c, u_int32_t len, int (*cb)(struct netbuf *))
 	c->rnb->buf = kore_malloc(c->rnb->m_len);
 }
 
+void 
+net_recv_cut(struct connection *c, u_int32_t offset, u_int32_t cut_len, u_int32_t len,int (*cb)(struct netbuf *))
+{
+    memcpy(c->rnb->buf, c->rnb->buf+offset, cut_len);
+    c->rnb->s_off = cut_len;
+    c->rnb->b_len = len;
+    c->rnb->cb = cb;
+    if (c->rnb->b_len <= c->rnb->m_len)
+         return;
+    c->rnb->buf = kore_realloc(c->rnb->buf, c->rnb->b_len);
+}
+
+struct kore_buf *
+net_buf_release_to_kore_buf(struct connection *c)
+{
+        struct kore_buf		*buf;
+	
+        buf = kore_malloc(sizeof(*buf));
+	buf->data = c->rnb->buf ;
+	buf->length = c->rnb->m_len;
+	buf->offset = c->rnb->s_off;
+
+        c->rnb->s_off = 0;
+        c->rnb->buf = kore_malloc(c->rnb->m_len);
+        return (buf);
+}
+
 void
 net_recv_queue(struct connection *c, u_int32_t len, int flags,
     int (*cb)(struct netbuf *))

--- a/src/utils.c
+++ b/src/utils.c
@@ -491,7 +491,7 @@ kore_mem_find(void *src, size_t slen, void *needle, u_int32_t len)
 		if (*p != *(u_int8_t *)needle)
 			continue;
 
-		if ((end - p) < len)
+		if ((u_int32_t)(end - p) < len)
 			return (NULL);
 
 		if (!memcmp(p, needle, len))


### PR DESCRIPTION
Hi Joris,

Within this change, I add 2 APIs about net_recv_buf to avoid memory copy of http_body. http_body are received and stored in net_rec_buf, after it's ready, the net buf is release to kore buf and net_buf is newly allocated. as you said, the implementation is a little bit tricky. 

In my test with curl, the http header and http body are received seperately, there is no  recv buf which include both http header and http body content. so, the memory copy can be avoided completely, in the case of 10kb file upload, I can see a significant time reduction.