### PR TITLE
cast difference between pointers as unsigned in kore_mem_find()

### DIFF
--- a/includes/kore.h
+++ b/includes/kore.h
@@ -514,7 +514,7 @@ int		kore_snprintf(char *, size_t, int *, const char *, ...);
 long long	kore_strtonum(const char *, int, long long, long long, int *);
 int		kore_base64_encode(u_int8_t *, u_int32_t, char **);
 int		kore_base64_decode(char *, u_int8_t **, u_int32_t *);
-void		*kore_mem_find(void *, size_t, void *, u_int32_t);
+void		*kore_mem_find(void *, size_t, void *, size_t);
 char		*kore_text_trim(char *, size_t);
 char		*kore_read_line(FILE *, char *, size_t);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -484,18 +484,17 @@ kore_base64_decode(char *in, u_int8_t **out, u_int32_t *olen)
 void *
 kore_mem_find(void *src, size_t slen, void *needle, u_int32_t len)
 {
-	u_int8_t	*p, *end;
+  size_t  pos;
 
-	end = (u_int8_t *)src + slen;
-	for (p = src; p < end; p++) {
-		if (*p != *(u_int8_t *)needle)
+  for(pos = 0; pos < slen; pos++) {
+		if ( *((u_int8_t *)src + pos) != *(u_int8_t *)needle)
 			continue;
 
-		if ((u_int32_t)(end - p) < len)
+		if ((slen - pos) < len)
 			return (NULL);
 
-		if (!memcmp(p, needle, len))
-			return (p);
+		if (!memcmp((u_int8_t *)src + pos, needle, len))
+			return ((u_int8_t *)src + pos);
 	}
 
 	return (NULL);

--- a/src/utils.c
+++ b/src/utils.c
@@ -491,7 +491,7 @@ kore_mem_find(void *src, size_t slen, void *needle, u_int32_t len)
 		if (*p != *(u_int8_t *)needle)
 			continue;
 
-		if ((end - p) < len)
+		if ((u_int32_t)(end - p) < len)
 			return (NULL);
 
 		if (!memcmp(p, needle, len))

--- a/src/utils.c
+++ b/src/utils.c
@@ -482,11 +482,11 @@ kore_base64_decode(char *in, u_int8_t **out, u_int32_t *olen)
 }
 
 void *
-kore_mem_find(void *src, size_t slen, void *needle, u_int32_t len)
+kore_mem_find(void *src, size_t slen, void *needle, size_t len)
 {
-  size_t  pos;
+	size_t  pos;
 
-  for(pos = 0; pos < slen; pos++) {
+	for(pos = 0; pos < slen; pos++) {
 		if ( *((u_int8_t *)src + pos) != *(u_int8_t *)needle)
 			continue;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -484,7 +484,7 @@ kore_base64_decode(char *in, u_int8_t **out, u_int32_t *olen)
 void *
 kore_mem_find(void *src, size_t slen, void *needle, size_t len)
 {
-	size_t  pos;
+	size_t		pos;
 
 	for(pos = 0; pos < slen; pos++) {
 		if ( *((u_int8_t *)src + pos) != *(u_int8_t *)needle)


### PR DESCRIPTION
This fixes a signed/unsigned comparison compiler error on NVIDIA Jetson TX1

$ gcc —version
gcc (Ubuntu/Linaro 4.8.4-2ubuntu1~14.04.1) 4.8.4
Copyright (C) 2013 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ make
… snip…
cc -Wall -Werror -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare -Iincludes -std=c99 -pedantic -DPREFIX='"/usr/local"' -O2 -D_GNU_SOURCE=1 -c src/utils.c -o src/utils.o
src/utils.c: In function ‘kore_mem_find’:
src/utils.c:494:17: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if ((end - p) < len)
