### PR TITLE
If we're iterating over rlimits, we should use rlim_t.

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -202,7 +202,7 @@ kore_worker_dispatch_signal(int sig)
 void
 kore_worker_entry(struct kore_worker *kw)
 {
-	size_t			fd;
+	rlim_t			fd;
 	struct rlimit		rl;
 	char			buf[16];
 	int			quit, had_lock, r;


### PR DESCRIPTION
I discovered this on freebsd/clang. Please let me know if this PR needs anything more.

> error: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'rlim_t' (aka 'long') [-Werror,-Wsign-compare]
