### PR TITLE
SHA256 checksum on modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INCLUDE_DIR=$(PREFIX)/include/kore
 
 S_SRC=	src/kore.c src/buf.c src/cli.c src/config.c src/connection.c \
 	src/domain.c src/mem.c src/msg.c src/module.c src/net.c \
-	src/pool.c src/timer.c src/utils.c src/worker.c
+	src/pool.c src/timer.c src/utils.c src/worker.c src/keymgr.c
 S_OBJS=	$(S_SRC:.c=.o)
 
 CFLAGS+=-Wall -Werror -Wstrict-prototypes -Wmissing-prototypes

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,11 @@ ifneq ("$(TASKS)", "")
 	CFLAGS+=-DKORE_USE_TASKS
 endif
 
+ifneq ("$(INTEGRITY)", "")
+LDFLAGS+=-lcrypto
+CFLAGS+=-DKORE_INTEGRITY_SHA256
+endif
+
 OSNAME=$(shell uname -s | sed -e 's/[-_].*//g' | tr A-Z a-z)
 ifeq ("$(OSNAME)", "darwin")
 	CFLAGS+=-I/opt/local/include/ -I/usr/local/opt/openssl/include

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Features
 * Only HTTPS connections allowed
 * Multiple modules can be loaded at once
 * Built-in asynchronous PostgreSQL support
-* private keys isolated in separate process
+* Private keys isolated in separate process
 * Default sane TLS ciphersuites (PFS in all major browsers)
 * Load your web application as a precompiled dynamic library
 * Modules can be reloaded on-the-fly, even while serving content

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Building Kore
 
 Requirements
 * openssl (latest is always the safest bet, right?)
-  (note: this requirement drops away when building with NOTLS=1 NOHTTP=1)
+  (note: this requirement drops away when building with NOTLS=1 NOHTTP=1
+   but its again required when building with INTEGRITY=1)
 
 Requirements for background tasks (optional)
 * pthreads
@@ -82,6 +83,7 @@ those by setting a shell environment variable before running **_make_**.
 * NOTLS=1 (compiles Kore without TLS)
 * NOHTTP=1 (compiles Kore without HTTP support)
 * NOOPT=1 (disable compiler optimizations)
+* INTEGRITY=1 (compiles sha256 hashing of modules for integrity check)
 
 Example libraries
 -----------------

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features
 * Only HTTPS connections allowed
 * Multiple modules can be loaded at once
 * Built-in asynchronous PostgreSQL support
+* private keys isolated in separate process
 * Default sane TLS ciphersuites (PFS in all major browsers)
 * Load your web application as a precompiled dynamic library
 * Modules can be reloaded on-the-fly, even while serving content

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -548,6 +548,7 @@ void		kore_domain_closelogs(void);
 void		*kore_module_getsym(const char *);
 void		kore_domain_load_crl(void);
 void		kore_module_load(const char *, const char *);
+void		kore_module_checksum(const char *, const char *);
 void		kore_domain_sslstart(struct kore_domain *);
 int		kore_module_handler_new(const char *, const char *,
 		    const char *, const char *, int);

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -604,7 +604,7 @@ void		kore_buf_append(struct kore_buf *, const void *, u_int32_t);
 u_int8_t	*kore_buf_release(struct kore_buf *, u_int32_t *);
 void		kore_buf_reset(struct kore_buf *);
 
-char	*kore_buf_stringify(struct kore_buf *);
+char	*kore_buf_stringify(struct kore_buf *, size_t *);
 void	kore_buf_appendf(struct kore_buf *, const char *, ...);
 void	kore_buf_appendv(struct kore_buf *, const char *, va_list);
 void	kore_buf_appendb(struct kore_buf *, struct kore_buf *);

--- a/includes/kore.h
+++ b/includes/kore.h
@@ -69,7 +69,7 @@ extern int daemon(int, int);
 #define errno_s			strerror(errno)
 #define ssl_errno_s		ERR_error_string(ERR_get_error(), NULL)
 
-#define KORE_DOMAINNAME_LEN		254
+#define KORE_DOMAINNAME_LEN		255
 #define KORE_PIDFILE_DEFAULT		"kore.pid"
 #define KORE_DEFAULT_CIPHER_LIST	"ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!kRSA:!kDSA"
 
@@ -370,9 +370,13 @@ struct kore_timer {
 	TAILQ_ENTRY(kore_timer)	list;
 };
 
+#define KORE_WORKER_KEYMGR	0
+
 /* Reserved message ids, registered on workers. */
 #define KORE_MSG_ACCESSLOG	1
 #define KORE_MSG_WEBSOCKET	2
+#define KORE_MSG_KEYMGR_REQ	3
+#define KORE_MSG_KEYMGR_RESP	4
 
 /* Predefined message targets. */
 #define KORE_MSG_PARENT		1000
@@ -384,6 +388,16 @@ struct kore_msg {
 	u_int16_t	dst;
 	u_int32_t	length;
 };
+
+#if !defined(KORE_NO_TLS)
+struct kore_keyreq {
+	int		padding;
+	char		domain[KORE_DOMAINNAME_LEN];
+	u_int8_t	domain_len;
+	u_int16_t	data_len;
+	u_int8_t	data[];
+};
+#endif
 
 extern pid_t	kore_pid;
 extern int	foreground;
@@ -426,6 +440,7 @@ void		kore_signal(int);
 void		kore_worker_wait(int);
 void		kore_worker_init(void);
 void		kore_worker_shutdown(void);
+void		kore_worker_privdrop(void);
 void		kore_worker_dispatch_signal(int);
 void		kore_worker_spawn(u_int16_t, u_int16_t);
 void		kore_worker_entry(struct kore_worker *);
@@ -463,6 +478,7 @@ void		kore_timer_remove(struct kore_timer *);
 struct kore_timer	*kore_timer_add(void (*cb)(void *, u_int64_t),
 			    u_int64_t, void *, int);
 
+void		kore_listener_cleanup(void);
 int		kore_server_bind(const char *, const char *, const char *);
 #if !defined(KORE_NO_TLS)
 int		kore_tls_sni_cb(SSL *, int *, void *);
@@ -541,15 +557,18 @@ void		kore_domain_cleanup(void);
 int		kore_domain_new(char *);
 void		kore_domain_free(struct kore_domain *);
 void		kore_module_init(void);
+void		kore_module_cleanup(void);
 void		kore_module_reload(int);
 void		kore_module_onload(void);
 int		kore_module_loaded(void);
 void		kore_domain_closelogs(void);
 void		*kore_module_getsym(const char *);
 void		kore_domain_load_crl(void);
+void		kore_domain_keymgr_init(void);
 void		kore_module_load(const char *, const char *);
 void		kore_module_checksum(const char *, const char *);
 void		kore_domain_sslstart(struct kore_domain *);
+void		kore_domain_callback(void (*cb)(struct kore_domain *));
 int		kore_module_handler_new(const char *, const char *,
 		    const char *, const char *, int);
 void		kore_module_handler_free(struct kore_module_handle *);
@@ -609,6 +628,9 @@ void	kore_buf_appendf(struct kore_buf *, const char *, ...);
 void	kore_buf_appendv(struct kore_buf *, const char *, va_list);
 void	kore_buf_appendb(struct kore_buf *, struct kore_buf *);
 void	kore_buf_replace_string(struct kore_buf *, char *, void *, size_t);
+
+void	kore_keymgr_run(void);
+void	kore_keymgr_cleanup(void);
 
 #if defined(__cplusplus)
 }

--- a/includes/pgsql.h
+++ b/includes/pgsql.h
@@ -67,6 +67,8 @@ void	kore_pgsql_continue(struct http_request *, struct kore_pgsql *);
 int	kore_pgsql_query(struct kore_pgsql *, const char *);
 int	kore_pgsql_query_params(struct kore_pgsql *,
 	    const char *, int, u_int8_t, ...);
+int	kore_pgsql_v_query_params(struct kore_pgsql *,
+	    const char *, int, u_int8_t, va_list);
 int	kore_pgsql_register(const char *, const char *);
 int	kore_pgsql_ntuples(struct kore_pgsql *);
 void	kore_pgsql_logerror(struct kore_pgsql *);

--- a/src/buf.c
+++ b/src/buf.c
@@ -78,7 +78,7 @@ kore_buf_appendv(struct kore_buf *buf, const char *fmt, va_list args)
 		b = sb;
 	}
 
-	kore_buf_append(buf, (u_int8_t *)b, l);
+	kore_buf_append(buf, b, l);
 	if (b != sb)
 		free(b);
 }

--- a/src/buf.c
+++ b/src/buf.c
@@ -94,12 +94,16 @@ kore_buf_appendf(struct kore_buf *buf, const char *fmt, ...)
 }
 
 char *
-kore_buf_stringify(struct kore_buf *buf)
+kore_buf_stringify(struct kore_buf *buf, size_t *len)
 {
 	char		c;
 
+	if (len != NULL)
+		*len = buf->offset;
+
 	c = '\0';
 	kore_buf_append(buf, &c, sizeof(c));
+
 	return ((char *)buf->data);
 }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -751,7 +751,7 @@ cli_build_asset(char *fpath, struct dirent *dp)
 
 	/* Start generating the file. */
 	cli_file_writef(out, "/* Auto generated */\n");
-	cli_file_writef(out, "#include <sys/param.h>\n\n");
+	cli_file_writef(out, "#include <sys/types.h>\n\n");
 
 	/* Write the file data as a byte array. */
 	cli_file_writef(out, "u_int8_t asset_%s_%s[] = {\n", name, ext);

--- a/src/cli.c
+++ b/src/cli.c
@@ -1206,7 +1206,7 @@ cli_build_cflags(struct buildopt *bopt)
 		    obopt->cflags->offset);
 	}
 
-	string = kore_buf_stringify(bopt->cflags);
+	string = kore_buf_stringify(bopt->cflags, NULL);
 	printf("CFLAGS=%s\n", string);
 	cflags_count = kore_split_string(string, " ", cflags, CFLAGS_MAX);
 }
@@ -1235,7 +1235,7 @@ cli_build_ldflags(struct buildopt *bopt)
 		    obopt->ldflags->offset);
 	}
 
-	string = kore_buf_stringify(bopt->ldflags);
+	string = kore_buf_stringify(bopt->ldflags, NULL);
 	printf("LDFLAGS=%s\n", string);
 	ldflags_count = kore_split_string(string, " ", ldflags, LD_FLAGS_MAX);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -451,6 +451,11 @@ configure_domain(char *options)
 		return (KORE_RESULT_ERROR);
 	}
 
+	if (strlen(argv[0]) >= KORE_DOMAINNAME_LEN - 1) {
+		printf("domain name '%s' too long\n", argv[0]);
+		return (KORE_RESULT_ERROR);
+	}
+
 	if (!kore_domain_new(argv[0])) {
 		printf("could not create new domain %s\n", argv[0]);
 		return (KORE_RESULT_ERROR);

--- a/src/config.c
+++ b/src/config.c
@@ -39,6 +39,7 @@
 static int		configure_include(char *);
 static int		configure_bind(char *);
 static int		configure_load(char *);
+static int		configure_checksum(char *);
 static int		configure_domain(char *);
 static int		configure_chroot(char *);
 static int		configure_runas(char *);
@@ -101,6 +102,7 @@ static struct {
 	{ "include",			configure_include },
 	{ "bind",			configure_bind },
 	{ "load",			configure_load },
+	{ "checksum",		configure_checksum },
 	{ "domain",			configure_domain },
 	{ "chroot",			configure_chroot },
 	{ "runas",			configure_runas },
@@ -294,6 +296,20 @@ configure_load(char *options)
 	kore_module_load(argv[0], argv[1]);
 	return (KORE_RESULT_OK);
 }
+
+#if !defined(KORE_NO_SHA256)
+static int
+configure_checksum(char *options)
+{
+	char		*argv[3];
+	kore_split_string(options, " ", argv, 3);
+	if (argv[0] == NULL)
+		return (KORE_RESULT_ERROR);
+
+	kore_module_checksum(argv[0], argv[1]);
+	return (KORE_RESULT_OK);
+}
+#endif
 
 #if !defined(KORE_NO_TLS)
 static int

--- a/src/config.c
+++ b/src/config.c
@@ -39,7 +39,11 @@
 static int		configure_include(char *);
 static int		configure_bind(char *);
 static int		configure_load(char *);
+
+#if defined(KORE_INTEGRITY_SHA256)
 static int		configure_checksum(char *);
+#endif
+
 static int		configure_domain(char *);
 static int		configure_chroot(char *);
 static int		configure_runas(char *);
@@ -102,7 +106,9 @@ static struct {
 	{ "include",			configure_include },
 	{ "bind",			configure_bind },
 	{ "load",			configure_load },
+#if defined(KORE_INTEGRITY_SHA256)
 	{ "checksum",		configure_checksum },
+#endif
 	{ "domain",			configure_domain },
 	{ "chroot",			configure_chroot },
 	{ "runas",			configure_runas },
@@ -297,7 +303,7 @@ configure_load(char *options)
 	return (KORE_RESULT_OK);
 }
 
-#if !defined(KORE_NO_SHA256)
+#if defined(KORE_INTEGRITY_SHA256)
 static int
 configure_checksum(char *options)
 {

--- a/src/domain.c
+++ b/src/domain.c
@@ -59,7 +59,7 @@ static int	keymgr_rsa_privenc(int, const unsigned char *,
 static ECDSA_SIG	*keymgr_ecdsa_sign(const unsigned char *, int,
 			    const BIGNUM *, const BIGNUM *, EC_KEY *);
 
-#if !defined(OpenBSD)
+#if !defined(LIBRESSL_VERSION_TEXT)
 /*
  * Run own ecdsa_method data structure as OpenSSL has this in ecs_locl.h
  * and does not export this on systems.
@@ -313,7 +313,7 @@ kore_domain_sslstart(struct kore_domain *dom)
 	 * Note that OpenBSD has since heartbleed removed freelists
 	 * from its OpenSSL in base so we don't need to care about it.
 	 */
-#if !defined(OpenBSD) || (OpenBSD < 201405)
+#if !defined(LIBRESSL_VERSION_TEXT)
 	dom->ssl_ctx->freelist_max_len = 0;
 #endif
 	SSL_CTX_set_mode(dom->ssl_ctx, SSL_MODE_ENABLE_PARTIAL_WRITE);

--- a/src/http.c
+++ b/src/http.c
@@ -915,7 +915,7 @@ http_populate_post(struct http_request *req)
 	if (req->http_body != NULL) {
 		body = NULL;
 		req->http_body->offset = req->content_length;
-		string = kore_buf_stringify(req->http_body);
+		string = kore_buf_stringify(req->http_body, NULL);
 	} else {
 		body = kore_buf_create(128);
 		for (;;) {
@@ -926,7 +926,7 @@ http_populate_post(struct http_request *req)
 				break;
 			kore_buf_append(body, data, ret);
 		}
-		string = kore_buf_stringify(body);
+		string = kore_buf_stringify(body, NULL);
 	}
 
 	v = kore_split_string(string, "&", args, HTTP_MAX_QUERY_ARGS);
@@ -1171,7 +1171,7 @@ multipart_parse_headers(struct http_request *req, struct kore_buf *in,
 	char		*headers[5], *args[5], *opt[5];
 	char		*d, *val, *name, *fname, *string;
 
-	string = kore_buf_stringify(hbuf);
+	string = kore_buf_stringify(hbuf, NULL);
 	h = kore_split_string(string, "\r\n", headers, 5);
 	for (i = 0; i < h; i++) {
 		c = kore_split_string(headers[i], ":", args, 5);
@@ -1252,7 +1252,7 @@ multipart_add_field(struct http_request *req, struct kore_buf *in,
 	}
 
 	data->offset -= 2;
-	string = kore_buf_stringify(data);
+	string = kore_buf_stringify(data, NULL);
 	http_argument_add(req, name, string);
 	kore_buf_free(data);
 }

--- a/src/keymgr.c
+++ b/src/keymgr.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2016 Joris Vink <joris@coders.se>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/param.h>
+
+#include <openssl/rsa.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include "kore.h"
+
+#if !defined(KORE_NO_TLS)
+struct key {
+	RSA			*rsa;
+	struct kore_domain	*dom;
+	TAILQ_ENTRY(key)	list;
+};
+
+static TAILQ_HEAD(, key)	keys;
+extern volatile sig_atomic_t	sig_recv;
+static int			initialized = 0;
+
+static void	keymgr_load_privatekey(struct kore_domain *);
+static void	keymgr_msg_recv(struct kore_msg *, const void *);
+
+void
+kore_keymgr_run(void)
+{
+	int		quit;
+
+	quit = 0;
+	initialized = 1;
+	TAILQ_INIT(&keys);
+
+	kore_listener_cleanup();
+	kore_module_cleanup();
+
+	kore_domain_callback(keymgr_load_privatekey);
+	kore_worker_privdrop();
+
+	net_init();
+	kore_connection_init();
+	kore_platform_event_init();
+
+	kore_msg_worker_init();
+	kore_msg_register(KORE_MSG_KEYMGR_REQ, keymgr_msg_recv);
+
+	kore_log(LOG_NOTICE, "key manager started");
+
+	while (quit != 1) {
+		if (sig_recv != 0) {
+			switch (sig_recv) {
+			case SIGQUIT:
+			case SIGINT:
+			case SIGTERM:
+				quit = 1;
+				break;
+			default:
+				break;
+			}
+			sig_recv = 0;
+		}
+
+		kore_platform_event_wait(1000);
+		kore_connection_prune(KORE_CONNECTION_PRUNE_DISCONNECT);
+	}
+
+	kore_keymgr_cleanup();
+	kore_platform_event_cleanup();
+	kore_connection_cleanup();
+	net_cleanup();
+}
+
+void
+kore_keymgr_cleanup(void)
+{
+	struct key		*key, *next;
+
+	kore_log(LOG_NOTICE, "cleaning up keys");
+
+	if (initialized == 0)
+		return;
+
+	for (key = TAILQ_FIRST(&keys); key != NULL; key = next) {
+		next = TAILQ_NEXT(key, list);
+		TAILQ_REMOVE(&keys, key, list);
+
+		RSA_free(key->rsa);
+		kore_mem_free(key);
+	}
+}
+
+static void
+keymgr_load_privatekey(struct kore_domain *dom)
+{
+	FILE			*fp;
+	struct key		*key;
+
+	if (dom->certkey == NULL)
+		return;
+
+	if ((fp = fopen(dom->certkey, "r")) == NULL)
+		fatal("failed to open private key: %s", dom->certkey);
+
+	key = kore_malloc(sizeof(*key));
+	key->dom = dom;
+
+	if ((key->rsa = PEM_read_RSAPrivateKey(fp, NULL, NULL, NULL)) == NULL)
+		fatal("PEM_read_RSAPrivateKey: %s", ssl_errno_s);
+
+	(void)fclose(fp);
+	kore_mem_free(dom->certkey);
+	dom->certkey = NULL;
+
+	TAILQ_INSERT_TAIL(&keys, key, list);
+}
+
+static void
+keymgr_msg_recv(struct kore_msg *msg, const void *data)
+{
+	int				ret;
+	const struct kore_keyreq	*req;
+	struct key			*key;
+	size_t				keylen;
+	u_int8_t			buf[1024];
+
+	if (msg->length < sizeof(*req))
+		return;
+
+	key = NULL;
+	req = (const struct kore_keyreq *)data;
+
+	if (msg->length != (sizeof(*req) + req->data_len))
+		return;
+
+	TAILQ_FOREACH(key, &keys, list) {
+		if (strncmp(key->dom->domain, req->domain, req->domain_len))
+			continue;
+
+		keylen = RSA_size(key->rsa);
+		if (req->data_len > keylen || keylen > sizeof(buf))
+			return;
+
+		ret = RSA_private_encrypt(req->data_len, req->data,
+		    buf, key->rsa, req->padding);
+		if (ret != RSA_size(key->rsa))
+			return;
+
+		kore_msg_send(msg->src, KORE_MSG_KEYMGR_RESP, buf, ret);
+		break;
+	}
+}
+
+#endif

--- a/src/kore.c
+++ b/src/kore.c
@@ -202,7 +202,7 @@ main(int argc, char *argv[])
 
 #if !defined(KORE_NO_TLS)
 int
-kore_tls_sni_cb(SSL *ssl, int *al, void *arg)
+kore_tls_sni_cb(SSL *ssl, int *ad, void *arg)
 {
 	struct kore_domain	*dom;
 	const char		*sname;
@@ -224,8 +224,7 @@ kore_tls_sni_cb(SSL *ssl, int *al, void *arg)
 		return (SSL_TLSEXT_ERR_OK);
 	}
 
-	*al = SSL_AD_HANDSHAKE_FAILURE;
-	return (SSL_TLSEXT_ERR_ALERT_FATAL);
+	return (SSL_TLSEXT_ERR_NOACK);
 }
 
 void

--- a/src/kore.c
+++ b/src/kore.c
@@ -202,7 +202,7 @@ main(int argc, char *argv[])
 
 #if !defined(KORE_NO_TLS)
 int
-kore_tls_sni_cb(SSL *ssl, int *ad, void *arg)
+kore_tls_sni_cb(SSL *ssl, int *al, void *arg)
 {
 	struct kore_domain	*dom;
 	const char		*sname;
@@ -224,7 +224,8 @@ kore_tls_sni_cb(SSL *ssl, int *ad, void *arg)
 		return (SSL_TLSEXT_ERR_OK);
 	}
 
-	return (SSL_TLSEXT_ERR_NOACK);
+	*al = SSL_AD_HANDSHAKE_FAILURE;
+	return (SSL_TLSEXT_ERR_ALERT_FATAL);
 }
 
 void

--- a/src/kore.c
+++ b/src/kore.c
@@ -98,8 +98,7 @@ version(void)
 int
 main(int argc, char *argv[])
 {
-	struct listener		*l;
-	int			ch, flags;
+	int		ch, flags;
 
 	flags = 0;
 
@@ -195,10 +194,9 @@ main(int argc, char *argv[])
 	if (!foreground)
 		unlink(kore_pidfile);
 
-	LIST_FOREACH(l, &listeners, list)
-		close(l->fd);
-
+	kore_listener_cleanup();
 	kore_log(LOG_NOTICE, "goodbye");
+
 	return (0);
 }
 
@@ -337,6 +335,19 @@ kore_server_bind(const char *ip, const char *port, const char *ccb)
 	}
 
 	return (KORE_RESULT_OK);
+}
+
+void
+kore_listener_cleanup(void)
+{
+	struct listener		*l;
+
+	while (!LIST_EMPTY(&listeners)) {
+		l = LIST_FIRST(&listeners);
+		LIST_REMOVE(l, list);
+		close(l->fd);
+		kore_mem_free(l);
+	}
 }
 
 void

--- a/src/module.c
+++ b/src/module.c
@@ -22,7 +22,7 @@
 
 #include "kore.h"
 
-#if !defined(KORE_NO_SHA256)
+#if defined(KORE_INTEGRITY_SHA256)
 #include <openssl/sha.h>
 #endif
 
@@ -80,7 +80,7 @@ kore_module_load(const char *path, const char *onload)
 	TAILQ_INSERT_TAIL(&modules, module, list);
 }
 
-#if !defined(KORE_NO_SHA256)
+#if defined(KORE_INTEGRITY_SHA256)
 void
 kore_module_checksum(const char *path, const char *checksum)
 {

--- a/src/module.c
+++ b/src/module.c
@@ -35,6 +35,21 @@ kore_module_init(void)
 }
 
 void
+kore_module_cleanup(void)
+{
+	struct kore_module	*module, *next;
+
+	for (module = TAILQ_FIRST(&modules); module != NULL; module = next) {
+		next = TAILQ_NEXT(module, list);
+		TAILQ_REMOVE(&modules, module, list);
+
+		kore_mem_free(module->path);
+		(void)dlclose(module->handle);
+		kore_mem_free(module);
+	}
+}
+
+void
 kore_module_load(const char *path, const char *onload)
 {
 	struct stat		st;

--- a/src/module.c
+++ b/src/module.c
@@ -15,10 +15,16 @@
  */
 
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
 
 #include <dlfcn.h>
 
 #include "kore.h"
+
+#if !defined(KORE_NO_SHA256)
+#include <openssl/sha.h>
+#endif
 
 static TAILQ_HEAD(, kore_module)	modules;
 
@@ -58,6 +64,119 @@ kore_module_load(const char *path, const char *onload)
 
 	TAILQ_INSERT_TAIL(&modules, module, list);
 }
+
+#if !defined(KORE_NO_SHA256)
+void
+kore_module_checksum(const char *path, const char *checksum)
+{
+	struct kore_module	*module;
+	struct kore_module	*remmod = NULL;
+	struct kore_module	*nxtmod = NULL;
+
+	int fd;
+	unsigned int len;
+	unsigned int tot=0;
+	int c;
+	const unsigned int chunk = 1024; // 1K
+	unsigned char buf[1024 +1];
+	unsigned char hash[SHA256_DIGEST_LENGTH];
+	char output[65];
+	SHA256_CTX sha256;
+
+	if(!checksum) {
+		kore_log(LOG_ERR,"invalid checksum configured: %s", checksum);
+		return;
+	}
+
+	kore_debug("kore_module_checksum(%s, %s)", path, checksum);
+
+	if(!SHA256_Init(&sha256)) {
+		kore_log(LOG_ERR,"SHA256_Init returns error");
+		return;
+	}
+
+	for(module = TAILQ_FIRST(&modules); module != NULL; module = nxtmod) {
+		nxtmod = TAILQ_NEXT(module, list);
+		if(remmod) {
+			TAILQ_REMOVE(&modules, remmod, list);
+			remmod = NULL;
+		}
+		if(strcmp(module->path, path))
+			continue;
+
+		// check sha256
+		fd = open(path, O_RDONLY);
+		if(fd<0) {
+			kore_log(LOG_ERR,"open error for checksum: %s",path);
+			kore_log(LOG_ERR,"%s",strerror(errno));
+			remmod = module;
+			continue;
+		}
+		do {
+			// read chunk of data in binary file
+			len = read(fd, buf, chunk);
+			if(len<1) {
+				kore_log(LOG_ERR,"read error on file: %s",path);
+				kore_log(LOG_ERR,"%s",strerror(errno));
+				remmod = module;
+				break;
+			}
+			// stop if NULL read
+			if(!len)
+				break;
+			tot+=len;
+
+			// stop if EOF reached
+			if(len<chunk) {
+				if(!SHA256_Update(&sha256,buf,len)) {
+					kore_log(LOG_ERR,"SHA256_Update returns error");
+					remmod = module;
+					break;
+				}
+				break;
+			}
+
+			// compute sha256 of chunk
+			if(!SHA256_Update(&sha256,buf,len)) {
+				kore_log(LOG_ERR,"SHA256_Update returns error");
+				remmod = module;
+				break;
+			}
+
+		} while(len>0);
+		close(fd);
+
+		if(!SHA256_Final(hash, &sha256)) {
+			kore_log(LOG_ERR,"SHA256_Final returns error");
+			remmod = module;
+			break;
+		}
+
+		for(c = 0; c < SHA256_DIGEST_LENGTH; c++) {
+			if(snprintf(output + (c * 2), 65, "%02x", hash[c]) >= 65 ) {
+				kore_log(LOG_ERR,"hash computation returns a string that is too big");
+				remmod = module;
+				break;
+			}
+		}
+
+		output[64] = 0;
+
+		if(strncmp(output,checksum, 65) ) {
+			kore_log(LOG_ERR,"checksum match failed: %s",path);
+			kore_log(LOG_ERR,"%s:\t%s",path,output);
+			kore_log(LOG_ERR,"conf:\t\t%s",checksum);
+			remmod = module;
+			continue;
+		}
+	}
+
+	if(remmod) {
+		TAILQ_REMOVE(&modules, remmod, list);
+		remmod = NULL;
+	}
+}
+#endif
 
 void
 kore_module_onload(void)

--- a/src/pgsql.c
+++ b/src/pgsql.c
@@ -150,11 +150,10 @@ kore_pgsql_query(struct kore_pgsql *pgsql, const char *query)
 }
 
 int
-kore_pgsql_query_params(struct kore_pgsql *pgsql,
-    const char *query, int result, u_int8_t count, ...)
+kore_pgsql_v_query_params(struct kore_pgsql *pgsql,
+    const char *query, int result, u_int8_t count, va_list args)
 {
 	u_int8_t	i;
-	va_list		args;
 	char		**values;
 	int		*lengths, *formats, ret;
 
@@ -164,8 +163,6 @@ kore_pgsql_query_params(struct kore_pgsql *pgsql,
 	}
 
 	if (count > 0) {
-		va_start(args, count);
-
 		lengths = kore_calloc(count, sizeof(int));
 		formats = kore_calloc(count, sizeof(int));
 		values = kore_calloc(count, sizeof(char *));
@@ -208,12 +205,27 @@ kore_pgsql_query_params(struct kore_pgsql *pgsql,
 	ret = KORE_RESULT_OK;
 
 cleanup:
-	if (count > 0)
-		va_end(args);
-
 	kore_mem_free(values);
 	kore_mem_free(lengths);
 	kore_mem_free(formats);
+
+	return (ret);
+}
+
+int
+kore_pgsql_query_params(struct kore_pgsql *pgsql,
+    const char *query, int result, u_int8_t count, ...)
+{
+	int		ret;
+	va_list		args;
+
+	if (count > 0)
+		va_start(args, count);
+
+	ret = kore_pgsql_v_query_params(pgsql, query, result, count, args);
+
+	if (count > 0)
+		va_end(args);
 
 	return (ret);
 }


### PR DESCRIPTION
A new 'checksum' directive in conf files now accepts the path to .so file and its sha256sum.
The checksum is compared to the matching module among already loaded modules.
The module is removed from the loaded list if the checksum is not matching. 