### PR TITLE
Added new function kore_pgsql_v_query_params().

### DIFF
--- a/includes/pgsql.h
+++ b/includes/pgsql.h
@@ -67,6 +67,8 @@ void	kore_pgsql_continue(struct http_request *, struct kore_pgsql *);
 int	kore_pgsql_query(struct kore_pgsql *, const char *);
 int	kore_pgsql_query_params(struct kore_pgsql *,
 	    const char *, int, u_int8_t, ...);
+int	kore_pgsql_v_query_params(struct kore_pgsql *,
+	    const char *, int, u_int8_t, va_list);
 int	kore_pgsql_register(const char *, const char *);
 int	kore_pgsql_ntuples(struct kore_pgsql *);
 void	kore_pgsql_logerror(struct kore_pgsql *);

--- a/src/pgsql.c
+++ b/src/pgsql.c
@@ -150,11 +150,10 @@ kore_pgsql_query(struct kore_pgsql *pgsql, const char *query)
 }
 
 int
-kore_pgsql_query_params(struct kore_pgsql *pgsql,
-    const char *query, int result, u_int8_t count, ...)
+kore_pgsql_v_query_params(struct kore_pgsql *pgsql,
+    const char *query, int result, u_int8_t count, va_list args)
 {
 	u_int8_t	i;
-	va_list		args;
 	char		**values;
 	int		*lengths, *formats, ret;
 
@@ -164,8 +163,6 @@ kore_pgsql_query_params(struct kore_pgsql *pgsql,
 	}
 
 	if (count > 0) {
-		va_start(args, count);
-
 		lengths = kore_calloc(count, sizeof(int));
 		formats = kore_calloc(count, sizeof(int));
 		values = kore_calloc(count, sizeof(char *));
@@ -208,12 +205,27 @@ kore_pgsql_query_params(struct kore_pgsql *pgsql,
 	ret = KORE_RESULT_OK;
 
 cleanup:
-	if (count > 0)
-		va_end(args);
-
 	kore_mem_free(values);
 	kore_mem_free(lengths);
 	kore_mem_free(formats);
+
+	return (ret);
+}
+
+int
+kore_pgsql_query_params(struct kore_pgsql *pgsql,
+    const char *query, int result, u_int8_t count, ...)
+{
+	int		ret;
+	va_list		args;
+
+	if (count > 0)
+		va_start(args, count);
+
+	ret = kore_pgsql_v_query_params(pgsql, query, result, count, args);
+
+	if (count > 0)
+		va_end(args);
 
 	return (ret);
 }


### PR DESCRIPTION
Same as kore_pgsql_query_params but takes a va_list as last parameter
(non-v version takes a variable list of parameters).

Lets people write easier to call wrappers around the query calls. I use
it in a wrapper that takes next states (error, current, continue) as
arguments in a handler with multiple async queries.

Of course, I'm open to rewrite it the way you would want or you can write it your way.