### PR TITLE
Compile and link C++ with g++ instead of gcc

### DIFF
--- a/examples/cpp/conf/build.conf
+++ b/examples/cpp/conf/build.conf
@@ -6,10 +6,14 @@ cflags=-Wall -Wmissing-declarations -Wshadow
 cflags=-Wstrict-prototypes -Wmissing-prototypes
 cflags=-Wpointer-arith -Wcast-qual -Wsign-compare
 
+cxxflags=-Wall -Wmissing-declarations -Wshadow
+cxxflags=-Wpointer-arith -Wcast-qual -Wsign-compare
+
 dev {
 	# These cflags are added to the shared ones when
 	# you build the "dev" flavor.
 	cflags=-g
+	cxxflags=-g
 }
 
 #prod {


### PR DESCRIPTION
This adds in compiling C++ with a C++ compiler, and also a `cxxflags` option similar to `cflags`. Corresponding issue is #131.