### PR TITLE
Optimize kore utils

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -100,16 +100,17 @@ kore_strlcpy(char *dst, const char *src, size_t len)
 {
 	char		*d = dst;
 	const char	*s = src;
-	const char	*end = dst + len - 1;
 
-	while ((*d = *s) != '\0') {
-		if (d == end) {
-			*d = '\0';
-			break;
+	if(len == 0){
+	/*if length not specified iterate looking for '\0'*/
+		while ((*d = *s) != '\0') {
+			d++;
+			s++;
 		}
-
-		d++;
-		s++;
+	}else{
+	/*if everything is as expected then go for memcpy*/
+		memcpy(d, s, len-1);
+        	*(d+len - 1) = '\0';
 	}
 }
 


### PR DESCRIPTION
@jorisvink  I feel that `kore_strlcpy` can be made better if it uses memcpy rather than manual iteration cause memcpy will use block copying rather than character iteration , i ran a manual **nano monotonic** clock to profile  on both the previous as well as memcpy version of `kore_strlcpy` and i noticed that memcpy  was approximately `0.000000100 sec` faster than previous version. I can provide those test codes which i used to profile both cases on my system (Model name:            Intel(R) Core(TM) i3 CPU       M 330  @ 2.13GHz 64bit ) , also memcpy perfectly fits into the scene if length is already known , even if length (length argument must be 0 for this case to take place ) is not know than it'll iterate like it used to do before until it finds a `\0`. Thank you :smile: 