### PR TITLE
Fix #153

### DIFF
--- a/includes/pgsql.h
+++ b/includes/pgsql.h
@@ -66,9 +66,9 @@ void	kore_pgsql_cleanup(struct kore_pgsql *);
 void	kore_pgsql_continue(struct http_request *, struct kore_pgsql *);
 int	kore_pgsql_query(struct kore_pgsql *, const char *);
 int	kore_pgsql_query_params(struct kore_pgsql *,
-	    const char *, int, u_int8_t, ...);
+	    const char *, int, int, ...);
 int	kore_pgsql_v_query_params(struct kore_pgsql *,
-	    const char *, int, u_int8_t, va_list);
+	    const char *, int, int, va_list);
 int	kore_pgsql_register(const char *, const char *);
 int	kore_pgsql_ntuples(struct kore_pgsql *);
 void	kore_pgsql_logerror(struct kore_pgsql *);

--- a/src/pgsql.c
+++ b/src/pgsql.c
@@ -151,7 +151,7 @@ kore_pgsql_query(struct kore_pgsql *pgsql, const char *query)
 
 int
 kore_pgsql_v_query_params(struct kore_pgsql *pgsql,
-    const char *query, int result, u_int8_t count, va_list args)
+    const char *query, int result, int count, va_list args)
 {
 	u_int8_t	i;
 	char		**values;
@@ -214,7 +214,7 @@ cleanup:
 
 int
 kore_pgsql_query_params(struct kore_pgsql *pgsql,
-    const char *query, int result, u_int8_t count, ...)
+    const char *query, int result, int count, ...)
 {
 	int		ret;
 	va_list		args;


### PR DESCRIPTION
Compiling with Clang 3.9 on FreeBSD raises the following error (see [1]):
```
src/pgsql.c:222:17: error: passing an object that undergoes default argument promotion to 'va_start'
      has undefined behavior [-Werror,-Wvarargs]
        va_start(args, count);
                       ^
src/pgsql.c:217:45: note: parameter of type 'u_int8_t' (aka 'unsigned char') is declared here
    const char *query, int result, u_int8_t count, ...)
```
More information about this warning can be found on [2].

To solve this we can change the type of `count` to `int` in
`kore_pgsql_query_params()` and `kore_pgsql_v_query_params()`. This
also matches the signatures of both `PQexecParams()` [3] and
`PQsendQueryParams()` [4].

[1] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=214639
[2] https://www.securecoding.cert.org/confluence/display/cplusplus/EXP58-CPP.+Pass+an+object+of+the+correct+type+to+va_start
[3] https://www.postgresql.org/docs/9.2/static/libpq-exec.html
[4] https://www.postgresql.org/docs/9.2/static/libpq-async.html