### PR TITLE
Fix fd leak in cli_buildopt_parse()

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -1307,6 +1307,8 @@ parse_option:
 			printf("ignoring unknown option '%s'\n", p);
 		}
 	}
+
+	fclose(fp);
 }
 
 static struct buildopt *


### PR DESCRIPTION
The build.conf file is left open when using `kore run`.

I'm experimenting with adding Capsicum support to kore and this was about the only unrestricted fd left.
Since kore forks worker processes afterwards it's left open in all of them. Better close it early :)