### PR TITLE
Skip server header when set

### DIFF
--- a/includes/http.h
+++ b/includes/http.h
@@ -215,6 +215,7 @@ void		kore_accesslog(struct http_request *);
 
 void		http_init(void);
 void		http_cleanup(void);
+void 		http_server_version(const char *);
 void		http_process(void);
 const char	*http_status_text(int);
 const char	*http_method_text(int);

--- a/src/http.c
+++ b/src/http.c
@@ -118,6 +118,19 @@ http_cleanup(void)
 	kore_pool_cleanup(&http_body_path);
 }
 
+void
+http_server_version(const char *version)
+{
+	int		l;
+
+	l = snprintf(http_version, sizeof(http_version),
+	    "server: %s\r\n", version);
+	if (l == -1 || (size_t)l >= sizeof(http_version))
+		fatal("http_server_version(): http_version buffer too small");
+
+	http_version_len = l;
+}
+
 int
 http_request_new(struct connection *c, const char *host,
     const char *method, const char *path, const char *version,


### PR DESCRIPTION
If the application sets the server header, prevent the server from adding another one.