### PR TITLE
add missing includes

### DIFF
--- a/includes/http.h
+++ b/includes/http.h
@@ -19,6 +19,9 @@
 #ifndef __H_HTTP_H
 #define __H_HTTP_H
 
+#include <sys/types.h>
+#include <sys/queue.h>
+
 #if defined(__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
to make includes order independent

previously defining

#include <kore/http.h>
#include <kore/kore.h>

wouldn't work as needed types in http.h are defined in kore.h
This solves it by including all needed headers.