### PR TITLE
Small fix in video stream example

### DIFF
--- a/examples/video_stream/src/stream.c
+++ b/examples/video_stream/src/stream.c
@@ -104,7 +104,7 @@ video_stream(struct http_request *req)
 		}
 
 		bytes++;
-		n = kore_split_string(bytes, "-", range, 2);
+		n = kore_split_string(bytes, "-", range, 3);
 		if (n == 0) {
 			v->ref--;
 			http_response(req, 416, NULL, 0);


### PR DESCRIPTION
With 2, we have max one element in the table because it's null
terminated...So we can't never get the end of the range.

Signed-off-by: Benjamin Hesmans <benjamin.hesmans@uclouvain.be>