### PR TITLE
add data associated with a connection

### DIFF
--- a/includes/kore.h
+++ b/includes/kore.h
@@ -202,6 +202,7 @@ struct connection {
 	struct kore_runtime_call	*ws_connect;
 	struct kore_runtime_call	*ws_message;
 	struct kore_runtime_call	*ws_disconnect;
+	struct kore_buf			*data;
 	TAILQ_HEAD(, http_request)	http_requests;
 #endif
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -76,6 +76,7 @@ kore_connection_new(void *owner)
 	c->ws_connect = NULL;
 	c->ws_message = NULL;
 	c->ws_disconnect = NULL;
+	c->data = NULL;
 	TAILQ_INIT(&(c->http_requests));
 #endif
 


### PR DESCRIPTION
This is used to store the client state data in websocket connections.

I allocate the buffer in ws_message and free it in ws_disconnect.