### PR TITLE
Ignore hidden files and some temporary editor files in assets

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -924,6 +924,11 @@ cli_build_asset(char *fpath, struct dirent *dp)
 	bopt = cli_buildopt_default();
 	name = cli_strdup(dp->d_name);
 
+	/* Ignore hidden files and some editor files */
+	if (name[0] == '.' || strrchr(name, '~') || strrchr(name, '#')) {
+		return;
+	}
+
 	/* Grab the extension as we're using it in the symbol name. */
 	if ((ext = strrchr(name, '.')) == NULL)
 		fatal("couldn't find ext in %s", name);

--- a/src/cli.c
+++ b/src/cli.c
@@ -922,12 +922,14 @@ cli_build_asset(char *fpath, struct dirent *dp)
 	char			hash[(SHA256_DIGEST_LENGTH * 2) + 1];
 
 	bopt = cli_buildopt_default();
-	name = cli_strdup(dp->d_name);
 
 	/* Ignore hidden files and some editor files */
-	if (name[0] == '.' || strrchr(name, '~') || strrchr(name, '#')) {
+	if (dp->d_name[0] == '.' ||
+	    strrchr(dp->d_name, '~') || strrchr(dp->d_name, '#')) {
 		return;
 	}
+
+	name = cli_strdup(dp->d_name);
 
 	/* Grab the extension as we're using it in the symbol name. */
 	if ((ext = strrchr(name, '.')) == NULL)


### PR DESCRIPTION
Some fix for building assets.

Before fix on macOS it builds some from hidden system files like .DS_Store, and probably just ignore hidden files.

```shell
CFLAGS=-Wall -Wmissing-declarations -Wshadow -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wcast-qual -Wsign-compare -fPIC -Isrc -Isrc/includes -I/usr/local/include -I/opt/local/include -I/usr/local/opt/openssl/include  -g 
LDFLAGS=-dynamiclib -undefined suppress -flat_namespace 
building asset .DS_Store
compiling .DS_Store
```

And for some editor like Emacs temporary files with `~` or `#` it blows with error, for example for file: `index.html~`, so I added them to fix.
