### PR TITLE
Websocket memory leak fix when using kore_websocket_send() to send data.

### DIFF
--- a/include/kore/kore.h
+++ b/include/kore/kore.h
@@ -596,6 +596,7 @@ char		*kore_read_line(FILE *, char *, size_t);
 #if !defined(KORE_NO_HTTP)
 void		kore_websocket_handshake(struct http_request *,
 		    const char *, const char *, const char *);
+int		kore_websocket_send_clean(struct netbuf *);
 void		kore_websocket_send(struct connection *,
 		    u_int8_t, const void *, size_t);
 void		kore_websocket_broadcast(struct connection *,

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -135,6 +135,13 @@ kore_websocket_handshake(struct http_request *req, const char *onconnect,
 		kore_runtime_wsconnect(req->owner->ws_connect, req->owner);
 }
 
+int
+kore_websocket_send_clean(struct netbuf *nb)
+{
+  	kore_free(nb->buf);
+  	return 0;
+}
+
 void
 kore_websocket_send(struct connection *c, u_int8_t op, const void *data,
     size_t len)
@@ -143,7 +150,7 @@ kore_websocket_send(struct connection *c, u_int8_t op, const void *data,
 
 	kore_buf_init(&frame, len);
 	websocket_frame_build(&frame, op, data, len);
-	net_send_stream(c, frame.data, frame.offset, NULL, NULL);
+	net_send_stream(c, frame.data, frame.offset, kore_websocket_send_clean, NULL);
 
 	/* net_send_stream() takes over the buffer data pointer. */
 	frame.data = NULL;


### PR DESCRIPTION
Websocket memory leak fix when using kore_websocket_send() to send data.