### PR TITLE
 Include clib's package reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,6 @@
   "name": "kore",
   "version": "2.0.0-release",
   "description": "An easy to use, scalable and secure web application framework for writing web APIs in C.",
-  "repo": "https://github.com/jorisvink/kore"
+  "repo": "https://github.com/jorisvink/kore",
+  "install": "make && make install"
 }

--- a/package.json
+++ b/package.json
@@ -3,5 +3,5 @@
   "version": "2.0.0-release",
   "description": "An easy to use, scalable and secure web application framework for writing web APIs in C.",
   "repo": "https://github.com/jorisvink/kore",
-  "install": "make && make install"
+  "install": "make"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "kore",
+  "version": "2.0.0-release",
+  "description": "An easy to use, scalable and secure web application framework for writing web APIs in C.",
+  "repo": "https://github.com/jorisvink/kore"
+}


### PR DESCRIPTION
This PR introduces a new top-level file, `package.json`, which enables this repository compatibility with [`clib`](https://github.com/clibs/clib), an open source C package manager.  By doing this, users of `clib` can quickly include the `libgit2` library within their project.

I'm not sure how version numbering occurs in `kore`.  If it is done manually, then this file must also be updated when a new version is released.  If not, additional changes to the versioning system must ensue, so as to update this file.