### PR TITLE
Adds Docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ INSTALL_DIR=$(PREFIX)/bin
 SHARE_DIR=$(PREFIX)/share/kore
 INCLUDE_DIR=$(PREFIX)/include/kore
 
+export PREFIX
+
 S_SRC=	src/kore.c src/buf.c src/config.c src/connection.c \
 	src/domain.c src/mem.c src/msg.c src/module.c src/net.c \
 	src/pool.c src/runtime.c src/timer.c src/utils.c src/worker.c \

--- a/share/man/kodev.1
+++ b/share/man/kodev.1
@@ -1,0 +1,81 @@
+.TH KODEV 1
+.SH NAME
+kodev \- Kore project management tool
+
+.SH SYNOPSIS
+.BR kodev
+[\fIOPTION\fR] ...
+
+.SH DESCRIPTION
+kore projects may be managed using the following OPTIONS;
+
+.BR help
+.RS
+Show the help synopsis.
+.RE
+
+.BR run
+.RS
+Run an application (\-fnr implied). The current directory is the path of the
+project to be run.
+.RE
+
+.BR reload
+.RS
+Reload the application (SIGHUP sent).
+.RE
+
+.BR build
+.RS
+Build the application. The properties of this build are read from
+.BR conf/build.conf
+.RE
+
+.BR info
+.RS
+Show info on kore on this system. Namely; active flavour, output type, kore
+features, kore source and kore binary.
+.RE
+
+.BR clean
+.RS
+Cleanup the build files.
+.RE
+
+.BR create
+.RS
+Create a new application skeleton with the name that is passed to it.
+.RE
+
+.BR flavour
+.RS
+Switch between build flavours with the argument being the new flavour.
+.RE
+
+.BR \-p
+.RS
+Option used in conjunction with \fBcreate\fR to generate an application for use
+with
+.BR pyko
+.RE
+
+.SH REPORTING BUGS, CONTRIBUTING && MORE
+If you run into any bugs, have suggestions or patches, please contact me at
+.BR <joris@coders.se>
+
+More information can be found at
+.BR <https://kore.io/>
+
+.SH AUTHOR
+.BR kore
+developed by Joris Vink
+.BR <joris@coders.se>
+
+Manpage authored by Guy Nankivell
+.BR <guynankivell@gmail.com>
+
+.SH LICENCE
+Usage of this software is provided under the
+.BR ISC
+license which may be found, with the source, at
+.BR <https://github.com/jorisvink/kore>


### PR DESCRIPTION
 have also added a man page entry for `kodev`. I have not modified the Makefile to install the man page -- This should be done when you are happy with the form. If you like the direction I will similarly build a technical documentation for `kore`. Should have done feature branch initially. Has now been polluted with makefile change