### PR TITLE
Undefine FORTIFY_SOURCE before defining it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ ifeq ("$(OSNAME)", "darwin")
 	LDFLAGS+=-L/opt/local/lib -L/usr/local/opt/openssl/lib
 	S_SRC+=src/bsd.c
 else ifeq ("$(OSNAME)", "linux")
-	CFLAGS+=-D_GNU_SOURCE=1 -D_FORTIFY_SOURCE=2
+	CFLAGS+=-D_GNU_SOURCE=1 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 	LDFLAGS+=-ldl
 	S_SRC+=src/linux.c
 else


### PR DESCRIPTION
This fixes gcc redefiniiton on distributions that define FORITFY SOURCE.
EG., https://bugzilla.mozilla.org/show_bug.cgi?id=1418398#c8

Signed-off-by: Bryan Baldwin <bryan@hardmodeze.ro>