### PR TITLE
Darwin update build proposal.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ ifneq ("$(SANITIZE)", "")
 endif
 
 ifeq ("$(OSNAME)", "darwin")
-	CFLAGS+=-I/opt/local/include/ -I/usr/local/opt/openssl/include
-	LDFLAGS+=-L/opt/local/lib -L/usr/local/opt/openssl/lib
+	CFLAGS+=-I$(OPENSSL_PATH)/include
+	LDFLAGS+=-L$(OPENSSL_PATH)/lib
 	S_SRC+=src/bsd.c
 else ifeq ("$(OSNAME)", "linux")
 	CFLAGS+=-D_GNU_SOURCE=1 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2

--- a/kodev/Makefile
+++ b/kodev/Makefile
@@ -28,8 +28,8 @@ endif
 
 OSNAME=$(shell uname -s | sed -e 's/[-_].*//g' | tr A-Z a-z)
 ifeq ("$(OSNAME)", "darwin")
-	CFLAGS+=-I/opt/local/include/ -I/usr/local/opt/openssl/include
-	LDFLAGS+=-L/opt/local/lib -L/usr/local/opt/openssl/lib
+	CFLAGS+=-I$(OPENSSL_PATH)/include/ -I$(OPENSSL_PATH)/include
+	LDFLAGS+=-L$(OPENSSL_PATH)/lib
 else ifeq ("$(OSNAME)", "linux")
 	CFLAGS+=-D_GNU_SOURCE=1
 endif


### PR DESCRIPTION
Mac M1 ARM64 which also supports X86 binaries can therefore have two
 openssl, the actual linking to the X86 path.
Also allowing cpu binding/affinity.