### PR TITLE
Fixing compiler error with -Werror,-Wignored-qualifiers

### DIFF
--- a/include/kore/kore.h
+++ b/include/kore/kore.h
@@ -1028,7 +1028,7 @@ int			kore_route_lookup(struct http_request *,
 #endif
 
 /* runtime.c */
-const size_t			kore_runtime_count(void);
+size_t kore_runtime_count(void);
 struct kore_runtime_call	*kore_runtime_getcall(const char *);
 struct kore_module		*kore_module_load(const char *,
 				    const char *, int);

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -76,7 +76,7 @@ static struct kore_runtime *runtimes[] = {
 	NULL
 };
 
-const size_t
+size_t
 kore_runtime_count(void)
 {
 	return ((sizeof(runtimes) / sizeof(runtimes[0])) - 1);


### PR DESCRIPTION
With the addition of the following clang compiler flags, kore builds fail on Mac OS:

`-Werror,-Wignored-qualifiers`

This PR removes the `const` qualifier from the `kore_runtime_count()` function declaration and definition (which is most likely harmless and simply extraneous).